### PR TITLE
Lift the repository cards on hover

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -34,6 +34,25 @@ h1 {
     }
 }
 
+.repository-card {
+    transition:
+        transform 0.15s ease-in-out,
+        box-shadow 0.15s ease-in-out;
+
+    &:hover {
+        transform: translateY(-0.25rem);
+        box-shadow: 0 0.5rem 1rem rgba(63, 76, 107, 0.25) !important;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        transition: none;
+
+        &:hover {
+            transform: none;
+        }
+    }
+}
+
 a.logo {
     text-decoration: none;
     color: rgba(63, 76, 107, 1);

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -39,7 +39,7 @@
         <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
             {% for repository in featured %}
                 <div class="col">
-                    <div class="card h-100 shadow-sm">
+                    <div class="card repository-card h-100 shadow-sm">
                         <div class="card-body pb-2">
                             <h5 class="card-title mb-2">
                                 <a class="text-reset text-decoration-none"


### PR DESCRIPTION
The cards on the start page had no hover feedback, even though the title is a link. They now lift by a quarter rem and deepen their shadow on hover, with the transform dropped under `prefers-reduced-motion`.

`!important` on the shadow is needed because Bootstrap's `.shadow-sm` utility carries it too.

Verified with `yarn build` (both rules land in the compiled stylesheet), `yarn check-style` and `bin/console lint:twig templates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)