### PR TITLE
Give a repository a page from the moment it is submitted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,9 +100,12 @@ main library anymore — `getMainRepository()` returns its most starred analysed
 - `GitHub/GitHubClient` — the only external source, wraps `api.github.com` (repository, owner, languages)
   behind a 1h cache. `GitHub/RepositoryIdentifier::fromInput()` parses everything users may paste
   (`vendor/repo`, https/ssh urls, deep links) and rejects any host but github.com.
-- `RepositorySubmitter` — validates a submission (unknown, duplicate, fork, empty, less than
-  `MIN_PHP_SHARE` PHP), creates the `Project` for its owner on the fly and dispatches `AnalyseRepository`.
-  Rejections are `Exception\SubmissionFailed`, whose messages are written to be shown to the submitter.
+- `RepositorySubmitter` — validates a submission (unknown, fork, empty, less than `MIN_PHP_SHARE` PHP),
+  creates the `Project` for its owner on the fly and dispatches `AnalyseRepository`. Rejections are
+  `Exception\SubmissionFailed`, whose messages are written to be shown to the submitter. A repository the
+  report already carries is **not** one of them: `submit()` returns a `Submission` that says whether this
+  submission is what queued it, so pasting a known repository is how people look it up — it is answered
+  from the database, before github.com is asked at all.
 - `RepositoryRefresher` — re-reads stars and metadata for everything submitted.
 - `ReleaseScanner` — which releases of a repository are missing: skips anything `GitTag::isPreRelease()`
   (contains `-`) or `isPatchRelease()` (not a plain `X.Y` / `X.Y.0` version) and anything already stored.
@@ -143,12 +146,15 @@ then spends one token of the `submission` rate limiter (5 per 15 minutes and IP)
 (`config/packages/csrf.yaml`): the token is a double submit cookie written by Symfony's `csrf-protection`
 Stimulus controller, which is why the hidden field carries `data-controller="csrf-protection"` and why
 reading the report never starts a session. Both rejections are flashes, not exceptions - a human mistyping
-twice should not get an error page.
+twice should not get an error page. Anything that gets through ends on the page of its repository, whether
+it was just queued or has been in the report for years.
 
 **Web** (`src/Controller/ReportController`) — routes are distinguished by `priority`, since `{vendor}` and
 `{id}` both match a single segment: `overview`/`submit` (3) > `repository` (2, digits only, returns JSON) >
 `project` (1, resolves the `Project` entity from the `vendor` route parameter, optional `?repository=<id>`
-preselects one of its repositories). `start` renders the submit form, the most starred repositories, the
+preselects one of its repositories). A project page exists from the moment something was submitted for it -
+a repository that carries no releases yet has no chart but a status telling the visitor it is queued or
+being measured right now. `start` renders the submit form, the most starred repositories, the
 vendors and what is still queued. `Repository::asGraph()` returns a `GraphData` value object that
 JSON-serializes into what the chart expects.
 

--- a/src/Command/RepositorySubmitCommand.php
+++ b/src/Command/RepositorySubmitCommand.php
@@ -32,7 +32,7 @@ final readonly class RepositorySubmitCommand
 
         foreach ($repositories as $submitted) {
             try {
-                $repository = $this->submitter->submit($submitted);
+                $submission = $this->submitter->submit($submitted);
             } catch (SubmissionFailed $exception) {
                 $io->error($exception->getMessage());
                 $failed = true;
@@ -40,9 +40,10 @@ final readonly class RepositorySubmitCommand
             }
 
             $io->text(sprintf(
-                ' * <options=bold>%s</> (%s stars) queued for analysis',
-                $repository->getName(),
-                number_format($repository->getStars())
+                ' * <options=bold>%s</> (%s stars) %s',
+                $submission->repository->getName(),
+                number_format($submission->repository->getStars()),
+                $submission->queued ? 'queued for analysis' : 'already part of the report'
             ));
         }
 

--- a/src/ComplexityReport/Exception/SubmissionFailed.php
+++ b/src/ComplexityReport/Exception/SubmissionFailed.php
@@ -22,11 +22,6 @@ final class SubmissionFailed extends \RuntimeException
         return new self(sprintf('There is no public repository github.com/%s.', $identifier));
     }
 
-    public static function alreadySubmitted(string $identifier): self
-    {
-        return new self(sprintf('Repository %s has been submitted already.', $identifier));
-    }
-
     public static function notSubmitted(string $identifier): self
     {
         return new self(sprintf('Repository %s is not part of the report.', $identifier));

--- a/src/ComplexityReport/RepositorySubmitter.php
+++ b/src/ComplexityReport/RepositorySubmitter.php
@@ -36,13 +36,25 @@ final class RepositorySubmitter
     ) {
     }
 
-    public function submit(string $input): Repository
+    public function submit(string $input): Submission
     {
-        $data = $this->client->getRepository(RepositoryIdentifier::fromInput($input));
+        $submitted = RepositoryIdentifier::fromInput($input);
+
+        // a repository the report already carries costs neither API quota nor a second row
+        $known = $this->repositoryRepository->findOneByName((string) $submitted);
+
+        if (null !== $known) {
+            return Submission::known($known);
+        }
+
+        $data = $this->client->getRepository($submitted);
         $identifier = (string) $data->identifier;
 
-        if (null !== $this->repositoryRepository->findOneByName($identifier)) {
-            throw SubmissionFailed::alreadySubmitted($identifier);
+        // github.com resolves names case insensitively, so what it returns can differ from what was pasted
+        $known = $this->repositoryRepository->findOneByName($identifier);
+
+        if (null !== $known) {
+            return Submission::known($known);
         }
 
         if ($data->fork) {
@@ -67,7 +79,7 @@ final class RepositorySubmitter
 
         $this->logger->info(sprintf('Submitted repository %s for analysis', $identifier));
 
-        return $repository;
+        return Submission::queued($repository);
     }
 
     private function loadProject(string $vendor): Project

--- a/src/ComplexityReport/Submission.php
+++ b/src/ComplexityReport/Submission.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport;
+
+use App\Entity\Repository;
+
+/**
+ * The outcome of a submission: the repository it points at, and whether this submission is what queued it.
+ *
+ * Submitting something the report already carries is not a failure - it is how people look a repository up,
+ * so the caller sends them to its page instead of rejecting them.
+ */
+final readonly class Submission
+{
+    private function __construct(
+        public Repository $repository,
+        public bool $queued,
+    ) {
+    }
+
+    public static function queued(Repository $repository): self
+    {
+        return new self($repository, true);
+    }
+
+    public static function known(Repository $repository): self
+    {
+        return new self($repository, false);
+    }
+}

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -65,19 +65,16 @@ final class ReportController extends AbstractController
         }
 
         try {
-            $repository = $submitter->submit((string) $request->request->get('repository', ''));
+            $submission = $submitter->submit((string) $request->request->get('repository', ''));
         } catch (SubmissionFailed $exception) {
             $this->addFlash('danger', $exception->getMessage());
 
             return $this->redirectToRoute('start');
         }
 
-        $this->addFlash('success', sprintf(
-            'Thanks! %s is queued and will show up here as soon as its releases are analysed.',
-            $repository->getName()
-        ));
-
-        return $this->redirectToRoute('start');
+        // a submission always ends on the page of its repository, which says what is happening to it -
+        // a known one is simply already there
+        return $this->toRepository($submission->repository);
     }
 
     #[Route('overview', name: 'overview', methods: 'GET', priority: 3)]
@@ -95,17 +92,15 @@ final class ReportController extends AbstractController
         #[MapEntity(mapping: ['vendor' => 'vendor'])] Project $project,
         Request $request,
     ): Response {
-        $repositories = $project->getAnalysedRepositories();
-
-        if ([] === $repositories) {
-            throw $this->createNotFoundException(sprintf('None of the repositories of %s is analysed yet.', $project->getVendor()));
-        }
+        $selected = $this->selectRepository($project, $request->query->getInt('repository'));
 
         return $this->render('chart.html.twig', [
             'headline' => sprintf('Project: %s', $project->getName()),
             'project' => $project,
-            'selectedRepositories' => [$this->selectRepository($project, $request->query->getInt('repository'))],
-            'repositories' => $repositories,
+            // a repository without releases has nothing to draw yet, the status below the headline says so
+            'selectedRepositories' => $selected->hasData() ? [$selected] : [],
+            'repositories' => $project->getAnalysedRepositories(),
+            'pendingRepository' => $selected->isAnalysed() ? null : $selected,
         ]);
     }
 
@@ -115,9 +110,23 @@ final class ReportController extends AbstractController
         return new JsonResponse($repository->asGraph()->getTagData());
     }
 
+    /**
+     * The page of a repository is the one of its project, with the repository preselected.
+     */
+    private function toRepository(Repository $repository): Response
+    {
+        return $this->redirectToRoute('project', [
+            'vendor' => $repository->getProject()->getVendor(),
+            'repository' => $repository->getId(),
+        ]);
+    }
+
+    /**
+     * Every repository can be picked, analysed or not - one that was just submitted has a page, too.
+     */
     private function selectRepository(Project $project, int $id): Repository
     {
-        foreach ($project->getAnalysedRepositories() as $repository) {
+        foreach ($project->getRepositories() as $repository) {
             if ($repository->getId() === $id) {
                 return $repository;
             }

--- a/templates/chart.html.twig
+++ b/templates/chart.html.twig
@@ -42,18 +42,39 @@
                     </a>
                 {% endif %}
             </h2>
-            <div data-controller="chart"
-                 data-repositories="{{ selectedRepositories|map(repository => repository.asGraph)|json_encode|e('html_attr') }}">
-                <canvas id="canvas" class="img-fluid"></canvas>
-                <div class="form-group mx-3 my-4">
-                    <h3>Repositories</h3>
-                    <select class="js-repository-select form-control" name="repositories[]" multiple="multiple">
-                        {% for repository in repositories %}
-                            <option value="{{ repository.id }}" {{ repository in selectedRepositories ? 'selected="selected"' }}>{{ repository.name }}</option>
-                        {% endfor %}
-                    </select>
+            {% if pendingRepository|default(false) %}
+                <div class="alert alert-info mt-3 mb-0">
+                    <i class="fas fa-hourglass-half"></i>
+                    {% if pendingRepository.hasData %}
+                        <strong>{{ pendingRepository.name }} is being analysed right now.</strong>
+                        {{ pendingRepository.tags|length }} of its releases are measured so far - reload this page
+                        to see the ones that followed.
+                    {% else %}
+                        <strong>{{ pendingRepository.name }} is queued for analysis.</strong>
+                        Every release of it is checked out and measured one by one, which takes a while -
+                        reload this page in a few minutes to see the first numbers.
+                    {% endif %}
                 </div>
-            </div>
+            {% elseif project is defined and repositories is empty %}
+                <div class="alert alert-warning mt-3 mb-0">
+                    None of the repositories of {{ project.name }} carries a release that could be measured.
+                </div>
+            {% endif %}
+
+            {% if repositories is not empty %}
+                <div data-controller="chart"
+                     data-repositories="{{ selectedRepositories|map(repository => repository.asGraph)|json_encode|e('html_attr') }}">
+                    <canvas id="canvas" class="img-fluid"></canvas>
+                    <div class="form-group mx-3 my-4">
+                        <h3>Repositories</h3>
+                        <select class="js-repository-select form-control" name="repositories[]" multiple="multiple">
+                            {% for repository in repositories %}
+                                <option value="{{ repository.id }}" {{ repository in selectedRepositories ? 'selected="selected"' }}>{{ repository.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </main>
 {% endblock %}

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -83,7 +83,8 @@
             <h2 class="mt-5 mb-3">Queued for Analysis</h2>
             <p class="text-muted">
                 {% for repository in pending %}
-                    <a href="{{ repository.url }}" target="_blank" rel="noreferrer" class="text-muted">{{ repository.name }}</a>{{ not loop.last ? ',' }}
+                    <a href="{{ path('project', {'vendor': repository.project.vendor, 'repository': repository.id}) }}"
+                       class="text-muted">{{ repository.name }}</a>{{ not loop.last ? ',' }}
                 {% endfor %}
             </p>
         {% endif %}


### PR DESCRIPTION
Two things a submitter could not do before: see anything after submitting, and reach a repository that is already in the report.

## The detail page exists right away

`project` used to 404 while none of a vendor's repositories was analysed, so the minutes between submitting and the first measured release had nothing to show. The page now renders from the moment something was submitted for that vendor, with a status instead of a chart:

- **queued** - nothing measured yet
- **being analysed right now** - with the number of releases already in
- and, for a vendor whose repositories carry no measurable release at all, a note saying so rather than a blank page

A repository that is still waiting can be preselected via `?repository=<id>`, which is where `submit` and the "Queued for Analysis" list on the start page now link. The chart section is only rendered when there is something to draw.

## Submitting a known repository leads to its chart

`RepositorySubmitter::submit()` returns a `Submission` - the repository, plus whether this submission is what queued it - instead of throwing `SubmissionFailed::alreadySubmitted()`. Pasting something the report already carries is how people look it up, so `submit` redirects to its page either way. The known case is answered from the database before github.com is asked, so a lookup costs no API quota.

The success flash is gone: the page it lands on already says the repository is queued, and saying it twice read as noise.

## Verified

`php-cs-fixer`, `phpstan`, `phpunit`, `lint:twig`, `lint:container` and `lint:yaml` are clean. Beyond that, against the local dataset: `/phpstan` (submitted, zero releases) renders the queued status where it used to 404, a repository temporarily flipped back to unanalysed renders the in-progress status next to its chart, and posting `phpstan/phpstan`, `https://github.com/WordPress/WordPress.git` and a freshly submitted repository each redirect to `/{vendor}?repository=<id>`. The rows and queue entries those checks created were removed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)