### PR TITLE
Reload the pending page while it waits for its releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,8 +160,10 @@ JSON-serializes into what the chart expects.
 
 **Frontend** — Vite + symfony/reprise + StimulusBundle. `assets/controllers/chart_controller.js` reads the
 preselected repositories from a `data-repositories` attribute rendered by `templates/chart.html.twig`, and
-lazily fetches additional ones from the `repository` JSON route when picked in the select2 box. Page
-transitions use symfony/ux-swup. `vite.config.js` takes the public path from `ASSET_BASE` (set by the build
+lazily fetches additional ones from the `repository` JSON route when picked in the select2 box.
+`refresh_controller.js` reloads the page every 30s while the status above the chart says a repository is
+queued or being measured - it is only rendered in that state, so the reloading stops by itself once the
+data is there, and a backgrounded tab skips its turn. Page transitions use symfony/ux-swup. `vite.config.js` takes the public path from `ASSET_BASE` (set by the build
 task in `deploy.php`) rather than the build mode, so local production builds keep working.
 
 ## Conventions

--- a/assets/controllers/refresh_controller.js
+++ b/assets/controllers/refresh_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from '@hotwired/stimulus';
+
+/*
+ * Reloads a page that is waiting for data. Analysing a repository happens in a worker, so its releases
+ * appear without anything happening in the browser - a visitor who just submitted would stare at a
+ * status that never changes.
+ */
+export default class extends Controller {
+    static values = {
+        interval: { type: Number, default: 30000 },
+    };
+
+    connect() {
+        this.timer = window.setInterval(() => {
+            // a forgotten tab reloads nothing while it is in the background, it catches up when looked at
+            if (!document.hidden) {
+                window.location.reload();
+            }
+        }, this.intervalValue);
+    }
+
+    disconnect() {
+        window.clearInterval(this.timer);
+    }
+}

--- a/templates/chart.html.twig
+++ b/templates/chart.html.twig
@@ -43,16 +43,16 @@
                 {% endif %}
             </h2>
             {% if pendingRepository|default(false) %}
-                <div class="alert alert-info mt-3 mb-0">
+                <div class="alert alert-info mt-3 mb-0" {{ stimulus_controller('refresh', {interval: 30000}) }}>
                     <i class="fas fa-hourglass-half"></i>
                     {% if pendingRepository.hasData %}
                         <strong>{{ pendingRepository.name }} is being analysed right now.</strong>
-                        {{ pendingRepository.tags|length }} of its releases are measured so far - reload this page
-                        to see the ones that followed.
+                        {{ pendingRepository.tags|length }} of its releases are measured so far - this page
+                        updates itself as more of them come in.
                     {% else %}
                         <strong>{{ pendingRepository.name }} is queued for analysis.</strong>
                         Every release of it is checked out and measured one by one, which takes a while -
-                        reload this page in a few minutes to see the first numbers.
+                        this page updates itself as soon as the first numbers are in.
                     {% endif %}
                 </div>
             {% elseif project is defined and repositories is empty %}


### PR DESCRIPTION
Follow-up to #10: the status page told visitors to reload it themselves, which is exactly what the browser can do.

`assets/controllers/refresh_controller.js` reloads the page every 30 seconds and is rendered on the status alert only, so it disappears - and the reloading stops - as soon as the repository has a chart. A tab sitting in the background skips its turn rather than reloading a page nobody is looking at.

The status wording follows: "reload this page" became "this page updates itself".

## Verified

`lint:twig`, `phpunit` and `yarn check-style` are clean. In a headless Chromium against the local dataset, `/phpstan` (submitted, no releases yet) requested itself at `12:15:31`, `12:16:01` and `12:16:31` - every 30s - while an analysed project page kept sitting there for 75s without a single reload, and a run with accelerated timers reloaded 1505 times, so the loop keeps going for as long as the repository is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)