### PR TITLE
Give the submit box the full width of the band

### DIFF
--- a/assets/styles/_screens.scss
+++ b/assets/styles/_screens.scss
@@ -6,26 +6,16 @@
 }
 
 // --- Start ------------------------------------------------------------------------------------
+// The input spans the band, with the label and the hint reading underneath it rather than beside it.
 .submit-band {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-6);
-    align-items: flex-start;
-    justify-content: space-between;
-
     &__intro {
-        max-width: 34ch;
+        margin-top: var(--space-3);
     }
 
     &__hint {
         margin-top: var(--space-2);
         font-size: var(--text-sm);
         color: var(--text-muted);
-    }
-
-    &__form {
-        flex: 1 1 420px;
-        max-width: 560px;
     }
 
     .alert {

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -109,43 +109,45 @@
 
         <div class="band">
             <div class="wrap submit-band">
+                {#
+                 # One box for both jobs. Picking a suggestion opens that repository, and anything the
+                 # report does not carry yet is posted to `submit`, which queues it and opens its page.
+                 # Without javascript the form still posts whatever was typed, which is what it did
+                 # before the suggestions existed.
+                 #}
+                <form action="{{ path('submit') }}" method="post" class="submit-form"
+                      {{ stimulus_controller('search', { url: path('search') }) }}>
+                    <input type="hidden" name="_token" value="{{ csrf_token('submit') }}"
+                           data-controller="csrf-protection">
+                    <div class="combobox">
+                        <input type="text" name="repository" class="field field--lg" required
+                               placeholder="Search the report, or paste owner/repository"
+                               aria-label="Search or add a GitHub repository"
+                               autocomplete="off" autocapitalize="off" spellcheck="false"
+                               role="combobox" aria-expanded="false" aria-autocomplete="list"
+                               aria-controls="search-suggestions"
+                               data-search-target="input"
+                               data-action="input->search#query keydown->search#navigate focus->search#query blur->search#close">
+                        <ul class="combobox__menu" id="search-suggestions" role="listbox"
+                            aria-label="Repositories" data-search-target="menu" hidden></ul>
+                    </div>
+                    <button type="submit" class="btn btn--lg">Add repository</button>
+                </form>
+                {% for label, messages in app.flashes(['success', 'danger']) %}
+                    {% for message in messages %}
+                        <div class="alert alert--{{ label }}">{{ message }}</div>
+                    {% endfor %}
+                {% endfor %}
+                {#
+                 # The box comes first and the words under it: the input is what the band is for, the
+                 # label and the hint only say what may be typed into it.
+                 #}
                 <div class="submit-band__intro">
                     <div class="eyebrow">Find or add a repository</div>
                     <p class="submit-band__hint">
                         Everything the report carries, plus every public repository on GitHub that is mostly
                         written in PHP - a composer.json is not needed.
                     </p>
-                </div>
-                <div class="submit-band__form">
-                    {#
-                     # One box for both jobs. Picking a suggestion opens that repository, and anything the
-                     # report does not carry yet is posted to `submit`, which queues it and opens its page.
-                     # Without javascript the form still posts whatever was typed, which is what it did
-                     # before the suggestions existed.
-                     #}
-                    <form action="{{ path('submit') }}" method="post" class="submit-form"
-                          {{ stimulus_controller('search', { url: path('search') }) }}>
-                        <input type="hidden" name="_token" value="{{ csrf_token('submit') }}"
-                               data-controller="csrf-protection">
-                        <div class="combobox">
-                            <input type="text" name="repository" class="field field--lg" required
-                                   placeholder="Search the report, or paste owner/repository"
-                                   aria-label="Search or add a GitHub repository"
-                                   autocomplete="off" autocapitalize="off" spellcheck="false"
-                                   role="combobox" aria-expanded="false" aria-autocomplete="list"
-                                   aria-controls="search-suggestions"
-                                   data-search-target="input"
-                                   data-action="input->search#query keydown->search#navigate focus->search#query blur->search#close">
-                            <ul class="combobox__menu" id="search-suggestions" role="listbox"
-                                aria-label="Repositories" data-search-target="menu" hidden></ul>
-                        </div>
-                        <button type="submit" class="btn btn--lg">Add repository</button>
-                    </form>
-                    {% for label, messages in app.flashes(['success', 'danger']) %}
-                        {% for message in messages %}
-                            <div class="alert alert--{{ label }}">{{ message }}</div>
-                        {% endfor %}
-                    {% endfor %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The band under the hero on the start page was a two-column layout: the "Find or add a repository" label and its hint on the left, the input box beside them.

The input is what the band is for, so it now spans the full width of the container, with the words reading underneath it — the label first, then the help text, both across the whole width as well.

Twig only carries the reordering; `.submit-band` drops its flex row and the width caps that went with it.

Checked: `yarn build`, `yarn check-style`, `bin/console lint:twig templates` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)