### PR TITLE
Roll the whole report up into one trend in the hero

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,8 @@ yarn check-style    # prettier over assets/
 ```
 
 Tests live under `App\Tests\` (PSR-4 → `tests/`) and cover the pure domain logic (input parsing, API
-mapping, release detection) — everything else needs a booted kernel and is not covered yet.
+mapping, release detection, the rolled up trends) — everything else needs a booted kernel and is not
+covered yet.
 
 ## Rebuilding the dataset
 
@@ -109,6 +110,14 @@ used to carry came from optional profile fields and named the wrong account as o
   submission is what queued it, so pasting a known repository is how people look it up — it is answered
   from the database, before github.com is asked at all.
 - `RepositoryRefresher` — re-reads stars and metadata for everything submitted.
+- `Trend/*` — the whole report rolled up into one figure per time frame (`TrendWindow`: YTD, 12 months,
+  5 years, all time), shown in the hero of the start page. `TrendCalculator` is pure: it takes a list of
+  `ReleasePoint`s and the current time and returns `Trend` value objects, which is why the rules live
+  there and are unit tested — only libraries already measured when a window opened take part in it, each
+  counts once and is represented by the release it stood at back then (all time compares every library
+  against its own first release). `TrendLoader` is the thin edge: one query via
+  `TagRepository::findReleasePoints()`, cached in `cache.app` for an hour under a key that carries the
+  day, since the windows move with it.
 - `ReleaseScanner` — which releases of a repository are missing: skips anything `GitTag::isPreRelease()`
   (contains `-`) or `isPatchRelease()` (not a plain `X.Y` / `X.Y.0` version) and anything already stored.
   `scanRemote()` reads refs with `git ls-remote` (no clone, no working copy), `scanWorkingCopy()` fetches
@@ -156,14 +165,17 @@ it was just queued or has been in the report for years.
 only, returns JSON) > `organization` (1, resolves the `Organization` entity from its `login`, optional
 `?repository=<id>` preselects one of its repositories). An organization page exists from the moment
 something was submitted for it - a repository that carries no releases yet has no chart but a status
-telling the visitor it is queued or being measured right now. `start` renders the submit form, the most
-starred repositories, the organizations and what is still queued. `Repository::asGraph()` returns a
+telling the visitor it is queued or being measured right now. `start` renders the trend in the hero, the
+submit form, the most starred repositories, the organizations and what is still queued.
+`Repository::asGraph()` returns a
 `GraphData` value object that
 JSON-serializes into what the chart expects.
 
 **Frontend** — Vite + symfony/reprise + StimulusBundle. `assets/controllers/chart_controller.js` reads the
 preselected repositories from a `data-repositories` attribute rendered by `templates/chart.html.twig`, and
 lazily fetches additional ones from the `repository` JSON route when picked in the select2 box.
+`trend_controller.js` switches the time frame of the hero figure, which is rendered for all four windows
+at once, so nothing is fetched when one is picked.
 `refresh_controller.js` reloads the page every 30s while the status above the chart says a repository is
 queued or being measured - it is only rendered in that state, so the reloading stops by itself once the
 data is there, and a backgrounded tab skips its turn. Page transitions use symfony/ux-swup. `vite.config.js` takes the public path from `ASSET_BASE` (set by the build

--- a/assets/controllers/trend_controller.js
+++ b/assets/controllers/trend_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from '@hotwired/stimulus';
+
+/*
+ * The time frames the hero figure can be read in. Like the rankings below, all of them are rendered
+ * with the request - picking one only swaps which is visible, nothing is fetched.
+ */
+export default class extends Controller {
+    static targets = ['tab', 'panel'];
+
+    select(event) {
+        const index = this.tabTargets.indexOf(event.currentTarget);
+
+        if (index < 0) {
+            return;
+        }
+
+        this.tabTargets.forEach((tab, position) => {
+            tab.setAttribute('aria-selected', position === index ? 'true' : 'false');
+        });
+
+        this.panelTargets.forEach((panel, position) => {
+            panel.hidden = position !== index;
+        });
+    }
+}

--- a/assets/styles/_base.scss
+++ b/assets/styles/_base.scss
@@ -157,6 +157,7 @@ canvas {
 
     &__inner {
         display: flex;
+        flex-wrap: wrap;
         gap: var(--space-7);
         align-items: center;
         justify-content: space-between;
@@ -185,6 +186,106 @@ canvas {
 
     .logo__title {
         color: var(--hero-fg);
+    }
+}
+
+// The right hand side of the start hero: the whole dataset as one figure, over the time frames it can
+// be read in. The trend tones of the design system are ink on white and would sink into the brand
+// ground, so the number borrows the lightened bars of the mark instead.
+.hero-trend {
+    flex: 0 0 auto;
+    width: clamp(260px, 26vw, 320px);
+    padding: var(--space-5);
+    background: rgba(255, 255, 255, 0.06);
+    border: var(--border-width) solid var(--hero-line);
+    border-radius: var(--radius-lg);
+
+    &__label {
+        font-family: var(--font-mono);
+        font-size: var(--text-eyebrow);
+        font-weight: var(--weight-medium);
+        letter-spacing: var(--tracking-eyebrow);
+        text-transform: uppercase;
+        color: var(--hero-faint);
+    }
+
+    &__figure {
+        margin-top: var(--space-4);
+
+        &[hidden] {
+            display: none;
+        }
+    }
+
+    &__value {
+        font-size: 38px;
+        font-weight: var(--weight-semibold);
+        letter-spacing: var(--tracking-heading);
+        line-height: var(--leading-heading);
+        font-variant-numeric: tabular-nums;
+        color: var(--hero-fg);
+
+        &--good {
+            color: var(--mark-low);
+        }
+
+        &--bad {
+            color: var(--mark-high);
+        }
+    }
+
+    &__caption {
+        margin-top: var(--space-2);
+        font-size: var(--text-sm);
+        color: var(--hero-muted);
+    }
+
+    &__since {
+        display: block;
+        margin-top: 2px;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--hero-faint);
+    }
+
+    // four equal columns, so the switch is one row at every width the card is given
+    &__windows {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: var(--space-1);
+        margin-top: var(--space-5);
+        padding-top: var(--space-4);
+        border-top: var(--border-width) solid var(--hero-line);
+    }
+
+    &__window {
+        padding: 4px 0;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--hero-faint);
+        background: transparent;
+        border: var(--border-width) solid transparent;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition:
+            color var(--transition),
+            background-color var(--transition);
+
+        &:hover {
+            color: var(--hero-fg);
+        }
+
+        &[aria-selected='true'] {
+            color: var(--hero-fg);
+            background: rgba(255, 255, 255, 0.12);
+            border-color: var(--hero-line);
+        }
+
+        // the brand tinted ring of the design system disappears on the brand ground
+        &:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.28);
+        }
     }
 }
 
@@ -297,5 +398,10 @@ canvas {
     // Too small to read as the mark, and the header carries it two rows further up anyway.
     .hero__mark {
         display: none;
+    }
+
+    // The figure is content, so it stays - it drops under the intro and takes the full width there.
+    .hero-trend {
+        width: 100%;
     }
 }

--- a/src/ComplexityReport/Trend/ReleasePoint.php
+++ b/src/ComplexityReport/Trend/ReleasePoint.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Trend;
+
+/**
+ * One measured release, reduced to what a trend is computed from - the whole report fits into a list of
+ * these, which is why the calculation never needs an entity or a database.
+ */
+final readonly class ReleasePoint
+{
+    public function __construct(
+        public int $repository,
+        public \DateTimeImmutable $created,
+        public float $averageComplexity,
+    ) {
+    }
+}

--- a/src/ComplexityReport/Trend/Trend.php
+++ b/src/ComplexityReport/Trend/Trend.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Trend;
+
+/**
+ * What the whole report did to its average complexity within one time frame.
+ *
+ * `from` and `to` are the mean average complexity over the libraries the window could compare - every
+ * library counts once, no matter how many releases or lines of code it carries.
+ */
+final readonly class Trend
+{
+    public function __construct(
+        public TrendWindow $window,
+        public float $from,
+        public float $to,
+        /**
+         * Change between the two, in percent - negative means the code got simpler.
+         */
+        public float $change,
+        /**
+         * How many libraries the figure is an average of.
+         */
+        public int $repositoryCount,
+        /**
+         * The date the window opened - `null` for all time, where every library starts at its own first
+         * release.
+         */
+        public ?\DateTimeImmutable $since = null,
+    ) {
+    }
+
+    /**
+     * A window nothing can be said about: no library was measured before it opened.
+     */
+    public static function withoutData(TrendWindow $window): self
+    {
+        return new self($window, 0.0, 0.0, 0.0, 0);
+    }
+
+    public function hasData(): bool
+    {
+        return $this->repositoryCount > 0;
+    }
+}

--- a/src/ComplexityReport/Trend/TrendCalculator.php
+++ b/src/ComplexityReport/Trend/TrendCalculator.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Trend;
+
+/**
+ * Rolls every measured release up into one figure per time frame: how the average complexity of the
+ * tracked libraries changed since the window opened.
+ *
+ * Two decisions make the number honest rather than merely computable:
+ *
+ * - Only libraries that were already measured when the window opened take part in it. A library that
+ *   was submitted last week would otherwise move the five year figure, although nothing about its code
+ *   changed - it would be the dataset growing, not the code getting hairier.
+ * - Every library counts once, weighted neither by releases nor by size, and it is represented by the
+ *   release it stood at when the window opened. A library that has not released since simply carries
+ *   its last measurement forward, which is what the chart shows for it as well.
+ *
+ * The class is pure on purpose: it takes a list of points and the current time and returns value
+ * objects, so everything about it can be tested without a database or a clock.
+ */
+final readonly class TrendCalculator
+{
+    /**
+     * One trend per window, in the order {@see TrendWindow::all()} declares them.
+     *
+     * @param list<ReleasePoint> $points
+     *
+     * @return list<Trend>
+     */
+    public function calculate(array $points, \DateTimeImmutable $now): array
+    {
+        return array_map(fn (TrendWindow $window) => $this->forWindow($points, $window, $now), TrendWindow::all());
+    }
+
+    /**
+     * @param list<ReleasePoint> $points
+     */
+    public function forWindow(array $points, TrendWindow $window, \DateTimeImmutable $now): Trend
+    {
+        $start = $window->startedAt($now);
+
+        /** @var array<int, ReleasePoint> $baseline */
+        $baseline = [];
+        /** @var array<int, ReleasePoint> $current */
+        $current = [];
+
+        foreach ($points as $point) {
+            // a release dated in the future is a lie the git history tells - it cannot be measured yet
+            if ($point->created > $now) {
+                continue;
+            }
+
+            $repository = $point->repository;
+
+            if (!isset($current[$repository]) || $point->created > $current[$repository]->created) {
+                $current[$repository] = $point;
+            }
+
+            if (null === $start) {
+                // all time: the oldest release of the library is where it started
+                if (!isset($baseline[$repository]) || $point->created < $baseline[$repository]->created) {
+                    $baseline[$repository] = $point;
+                }
+            } elseif ($point->created <= $start
+                && (!isset($baseline[$repository]) || $point->created > $baseline[$repository]->created)) {
+                // otherwise: the release the library stood at when the window opened
+                $baseline[$repository] = $point;
+            }
+        }
+
+        $from = [];
+        $to = [];
+
+        foreach ($baseline as $repository => $point) {
+            $from[] = $point->averageComplexity;
+            $to[] = $current[$repository]->averageComplexity;
+        }
+
+        if ([] === $from) {
+            return Trend::withoutData($window);
+        }
+
+        $fromMean = array_sum($from) / \count($from);
+        $toMean = array_sum($to) / \count($to);
+
+        if (0.0 === $fromMean) {
+            return Trend::withoutData($window);
+        }
+
+        return new Trend(
+            $window,
+            round($fromMean, 2),
+            round($toMean, 2),
+            round((($toMean - $fromMean) / $fromMean) * 100, 1),
+            \count($from),
+            $start,
+        );
+    }
+}

--- a/src/ComplexityReport/Trend/TrendLoader.php
+++ b/src/ComplexityReport/Trend/TrendLoader.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Trend;
+
+use App\Repository\TagRepository;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * The trends of the start page: every release the report carries, rolled up per time frame.
+ *
+ * Reading every tag for a figure that only moves when a release is measured would be wasteful, so the
+ * result is cached - keyed by the day, because the windows themselves move with it.
+ */
+final readonly class TrendLoader
+{
+    private const int TTL = 3600;
+
+    public function __construct(
+        private TagRepository $tagRepository,
+        private TrendCalculator $calculator,
+        private CacheInterface $cache,
+    ) {
+    }
+
+    /**
+     * @return list<Trend>
+     */
+    public function load(): array
+    {
+        $now = new \DateTimeImmutable();
+
+        return $this->cache->get(
+            sprintf('complexity_report.trends.%s', $now->format('Y-m-d')),
+            function (ItemInterface $item) use ($now): array {
+                $item->expiresAfter(self::TTL);
+
+                return $this->calculator->calculate($this->tagRepository->findReleasePoints(), $now);
+            }
+        );
+    }
+}

--- a/src/ComplexityReport/Trend/TrendWindow.php
+++ b/src/ComplexityReport/Trend/TrendWindow.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Trend;
+
+/**
+ * The time frames the hero rolls the whole report up into.
+ *
+ * A window is a point in the past the dataset is compared against - except for all time, which has no
+ * fixed start: there every library is compared against its own first measured release.
+ */
+enum TrendWindow: string
+{
+    case YearToDate = 'ytd';
+    case TwelveMonths = '12m';
+    case FiveYears = '5y';
+    case AllTime = 'all';
+
+    /**
+     * @return list<self>
+     */
+    public static function all(): array
+    {
+        return self::cases();
+    }
+
+    /**
+     * The label on the switch in the hero - four of them share one row, so they are as short as the
+     * mono type they are set in. {@see self::title()} spells them out.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::YearToDate => 'YTD',
+            self::TwelveMonths => '12M',
+            self::FiveYears => '5Y',
+            self::AllTime => 'All',
+        };
+    }
+
+    public function title(): string
+    {
+        return match ($this) {
+            self::YearToDate => 'Year to date',
+            self::TwelveMonths => 'Last 12 months',
+            self::FiveYears => 'Last 5 years',
+            self::AllTime => 'All time',
+        };
+    }
+
+    /**
+     * When the window opens - `null` for all time, which starts at the first release of every library
+     * rather than at a date they all share.
+     */
+    public function startedAt(\DateTimeImmutable $now): ?\DateTimeImmutable
+    {
+        return match ($this) {
+            self::YearToDate => $now->setDate((int) $now->format('Y'), 1, 1)->setTime(0, 0),
+            self::TwelveMonths => $now->sub(new \DateInterval('P1Y')),
+            self::FiveYears => $now->sub(new \DateInterval('P5Y')),
+            self::AllTime => null,
+        };
+    }
+}

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -9,6 +9,7 @@ use App\ComplexityReport\Ranking;
 use App\ComplexityReport\RepositorySearch;
 use App\ComplexityReport\RepositorySubmitter;
 use App\ComplexityReport\StatisticsLoader;
+use App\ComplexityReport\Trend\TrendLoader;
 use App\Entity\Organization;
 use App\Entity\Repository;
 use App\Repository\OrganizationRepository;
@@ -43,6 +44,7 @@ final class ReportController extends AbstractController
         RepositoryRepository $repositoryRepository,
         OrganizationRepository $organizationRepository,
         StatisticsLoader $statisticsLoader,
+        TrendLoader $trendLoader,
     ): Response {
         // one query for every ranking - they all sort the same set, only by a different measurement
         $analysed = $repositoryRepository->findAnalysedWithTags();
@@ -57,6 +59,7 @@ final class ReportController extends AbstractController
             'organizations' => $organizationRepository->findWithData(),
             'pending' => $repositoryRepository->findPending(),
             'statistics' => $statisticsLoader->load(),
+            'trends' => $trendLoader->load(),
         ]);
     }
 

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\ComplexityReport\Trend\ReleasePoint;
 use App\Entity\Tag;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -16,6 +17,28 @@ final class TagRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Tag::class);
+    }
+
+    /**
+     * Every measured release reduced to the three values a trend is computed from - the whole report as
+     * one query, without hydrating a single entity.
+     *
+     * @return list<ReleasePoint>
+     */
+    public function findReleasePoints(): array
+    {
+        /** @var list<array{repository: int|string, created: \DateTimeImmutable, complexity: float|string}> $rows */
+        $rows = $this->createQueryBuilder('t')
+            ->select('IDENTITY(t.repository) AS repository, t.created AS created, t.averageComplexity AS complexity')
+            ->orderBy('t.created', 'ASC')
+            ->addOrderBy('t.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return array_map(
+            static fn (array $row) => new ReleasePoint((int) $row['repository'], $row['created'], (float) $row['complexity']),
+            $rows
+        );
     }
 
     public function getLinesOfCodeSum(): int

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -103,7 +103,56 @@
                         </div>
                     </dl>
                 </div>
-                {{ include('mark.html.twig', {size: 168, ground: false, class: 'hero__mark'}) }}
+                {#
+                 # The report in one number: what the average complexity of everything it tracks did
+                 # within the chosen time frame. All four are rendered, so switching one on is a matter
+                 # of hiding the others - without javascript the year to date figure is the one that
+                 # stands. Nothing measured yet means nothing to roll up, and the mark closes the row
+                 # like it did before.
+                 #}
+                {% if hasData %}
+                    <div class="hero-trend" {{ stimulus_controller('trend') }}>
+                        <div class="hero-trend__label">Average complexity</div>
+                        {% for trend in trends %}
+                            <div class="hero-trend__figure" role="tabpanel" id="trend-{{ trend.window.value }}"
+                                 aria-labelledby="trend-tab-{{ trend.window.value }}"
+                                 data-trend-target="panel" {{ not loop.first ? 'hidden' }}>
+                                {% if trend.hasData %}
+                                    <div class="hero-trend__value hero-trend__value--{{ trend.change|trend_tone }}">
+                                        {{ trend.change|signed_percent }}
+                                    </div>
+                                    <p class="hero-trend__caption">
+                                        Ø {{ trend.from|number_format(2) }} → {{ trend.to|number_format(2) }}
+                                        across {{ trend.repositoryCount|number_format }}
+                                        {{ trend.repositoryCount == 1 ? 'library' : 'libraries' }}
+                                        <span class="hero-trend__since">
+                                            {{ trend.since ? 'since %s'|format(trend.since|date('F j, Y')) : 'since their own first release' }}
+                                        </span>
+                                    </p>
+                                {% else %}
+                                    <div class="hero-trend__value hero-trend__value--flat">–</div>
+                                    <p class="hero-trend__caption">
+                                        Nothing was measured before this time frame opened.
+                                    </p>
+                                {% endif %}
+                            </div>
+                        {% endfor %}
+                        <div class="hero-trend__windows" role="tablist" aria-label="Time frame">
+                            {% for trend in trends %}
+                                <button type="button" class="hero-trend__window" role="tab"
+                                        id="trend-tab-{{ trend.window.value }}"
+                                        aria-controls="trend-{{ trend.window.value }}"
+                                        aria-selected="{{ loop.first ? 'true' : 'false' }}"
+                                        title="{{ trend.window.title }}"
+                                        data-trend-target="tab" data-action="trend#select">
+                                    {{ trend.window.label }}
+                                </button>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% else %}
+                    {{ include('mark.html.twig', {size: 168, ground: false, class: 'hero__mark'}) }}
+                {% endif %}
             </div>
         </header>
 

--- a/tests/ComplexityReport/Trend/TrendCalculatorTest.php
+++ b/tests/ComplexityReport/Trend/TrendCalculatorTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\ComplexityReport\Trend;
+
+use App\ComplexityReport\Trend\ReleasePoint;
+use App\ComplexityReport\Trend\Trend;
+use App\ComplexityReport\Trend\TrendCalculator;
+use App\ComplexityReport\Trend\TrendWindow;
+use PHPUnit\Framework\TestCase;
+
+final class TrendCalculatorTest extends TestCase
+{
+    private const string NOW = '2026-07-31 12:00:00';
+
+    /**
+     * @dataProvider windows
+     */
+    public function testItRollsTheReportUpPerWindow(
+        TrendWindow $window,
+        float $from,
+        float $to,
+        float $change,
+        int $repositoryCount,
+    ): void {
+        $trend = $this->calculate($window, self::report());
+
+        self::assertTrue($trend->hasData());
+        self::assertSame($window, $trend->window);
+        self::assertSame($from, $trend->from);
+        self::assertSame($to, $trend->to);
+        self::assertSame($change, $trend->change);
+        self::assertSame($repositoryCount, $trend->repositoryCount);
+    }
+
+    /**
+     * The figures of {@see self::report()}, worked out by hand:
+     *
+     * - year to date compares 7.0 / 20.0 against 6.0 / 25.0, so 13.5 against 15.5
+     * - twelve months reaches back to the 8.0 of `1`, so 14.0 against 15.5
+     * - five years reaches back to its 10.0, so 15.0 against 15.5
+     * - all time adds `3` at its own first release, so 20.0 against 21.33
+     *
+     * @return iterable<string, array{TrendWindow, float, float, float, int}>
+     */
+    public static function windows(): iterable
+    {
+        yield 'year to date' => [TrendWindow::YearToDate, 13.5, 15.5, 14.8, 2];
+        yield 'twelve months' => [TrendWindow::TwelveMonths, 14.0, 15.5, 10.7, 2];
+        yield 'five years' => [TrendWindow::FiveYears, 15.0, 15.5, 3.3, 2];
+        yield 'all time' => [TrendWindow::AllTime, 20.0, 21.33, 6.7, 3];
+    }
+
+    public function testItCountsALibraryOnlyOnceNoMatterHowManyReleasesItHas(): void
+    {
+        // `1` brings four releases to the window and `2` a single one - both weigh the same
+        self::assertSame(2, $this->calculate(TrendWindow::YearToDate, self::report())->repositoryCount);
+    }
+
+    public function testItLeavesOutLibrariesThatWereNotMeasuredWhenTheWindowOpened(): void
+    {
+        $withoutNewcomer = array_values(array_filter(
+            self::report(),
+            static fn (ReleasePoint $point) => 3 !== $point->repository
+        ));
+
+        // `3` was first measured in April 2026, so it moves all time - and nothing before it
+        self::assertEquals(
+            $this->calculate(TrendWindow::FiveYears, $withoutNewcomer),
+            $this->calculate(TrendWindow::FiveYears, self::report())
+        );
+        self::assertNotEquals(
+            $this->calculate(TrendWindow::AllTime, $withoutNewcomer),
+            $this->calculate(TrendWindow::AllTime, self::report())
+        );
+    }
+
+    public function testItCarriesTheLastReleaseOfALibraryThatStoppedReleasingForward(): void
+    {
+        $abandoned = [
+            new ReleasePoint(1, new \DateTimeImmutable('2015-01-01'), 12.0),
+            new ReleasePoint(1, new \DateTimeImmutable('2016-01-01'), 14.0),
+        ];
+
+        $trend = $this->calculate(TrendWindow::TwelveMonths, $abandoned);
+
+        // it was measured before the window opened and did not move within it
+        self::assertSame(1, $trend->repositoryCount);
+        self::assertSame(14.0, $trend->from);
+        self::assertSame(14.0, $trend->to);
+        self::assertSame(0.0, $trend->change);
+    }
+
+    public function testAllTimeComparesEveryLibraryAgainstItsOwnFirstRelease(): void
+    {
+        $trend = $this->calculate(TrendWindow::AllTime, self::report());
+
+        self::assertNull($trend->since);
+        // the first releases are 10.0, 20.0 and 30.0
+        self::assertSame(20.0, $trend->from);
+    }
+
+    public function testEveryOtherWindowKnowsTheDateItOpened(): void
+    {
+        $trend = $this->calculate(TrendWindow::YearToDate, self::report());
+
+        self::assertSame('2026-01-01', $trend->since?->format('Y-m-d'));
+    }
+
+    public function testItIgnoresReleasesDatedAfterTheGivenTime(): void
+    {
+        $points = array_merge(self::report(), [
+            new ReleasePoint(1, new \DateTimeImmutable('2030-01-01'), 99.0),
+        ]);
+
+        self::assertEquals(
+            $this->calculate(TrendWindow::AllTime, self::report()),
+            $this->calculate(TrendWindow::AllTime, $points)
+        );
+    }
+
+    public function testItDoesNotCareInWhichOrderTheReleasesArrive(): void
+    {
+        self::assertEquals(
+            $this->calculate(TrendWindow::AllTime, self::report()),
+            $this->calculate(TrendWindow::AllTime, array_reverse(self::report()))
+        );
+    }
+
+    public function testAWindowNothingReachesBackToHasNoData(): void
+    {
+        $newcomerOnly = [new ReleasePoint(3, new \DateTimeImmutable('2026-04-01'), 30.0)];
+
+        $trend = $this->calculate(TrendWindow::YearToDate, $newcomerOnly);
+
+        self::assertFalse($trend->hasData());
+        self::assertSame(0, $trend->repositoryCount);
+        self::assertSame(0.0, $trend->change);
+        self::assertSame(TrendWindow::YearToDate, $trend->window);
+    }
+
+    public function testALibraryMeasuredAsZeroHasNothingToComparePercentagesAgainst(): void
+    {
+        $points = [new ReleasePoint(1, new \DateTimeImmutable('2015-01-01'), 0.0)];
+
+        // nothing to divide by - a percentage of zero complexity says nothing
+        self::assertFalse($this->calculate(TrendWindow::AllTime, $points)->hasData());
+    }
+
+    public function testItAnswersEveryWindowAtOnceInTheOrderTheyAreDeclaredIn(): void
+    {
+        $trends = (new TrendCalculator())->calculate(self::report(), new \DateTimeImmutable(self::NOW));
+
+        self::assertSame(
+            TrendWindow::all(),
+            array_map(static fn (Trend $trend) => $trend->window, $trends)
+        );
+    }
+
+    public function testAnEmptyReportAnswersEveryWindowWithoutData(): void
+    {
+        $trends = (new TrendCalculator())->calculate([], new \DateTimeImmutable(self::NOW));
+
+        self::assertCount(4, $trends);
+
+        foreach ($trends as $trend) {
+            self::assertFalse($trend->hasData());
+        }
+    }
+
+    /**
+     * @param list<ReleasePoint> $points
+     */
+    private function calculate(TrendWindow $window, array $points): Trend
+    {
+        return (new TrendCalculator())->forWindow($points, $window, new \DateTimeImmutable(self::NOW));
+    }
+
+    /**
+     * Three libraries, seen from 2026-07-31: `1` releases regularly and gets simpler, `2` released twice
+     * and got hairier, `3` was submitted this spring and has no history to compare against.
+     *
+     * @return list<ReleasePoint>
+     */
+    private static function report(): array
+    {
+        return [
+            new ReleasePoint(1, new \DateTimeImmutable('2018-01-01'), 10.0),
+            new ReleasePoint(1, new \DateTimeImmutable('2024-06-01'), 8.0),
+            new ReleasePoint(1, new \DateTimeImmutable('2025-12-01'), 7.0),
+            new ReleasePoint(1, new \DateTimeImmutable('2026-03-01'), 6.0),
+            new ReleasePoint(2, new \DateTimeImmutable('2020-01-01'), 20.0),
+            new ReleasePoint(2, new \DateTimeImmutable('2026-05-01'), 25.0),
+            new ReleasePoint(3, new \DateTimeImmutable('2026-04-01'), 30.0),
+            new ReleasePoint(3, new \DateTimeImmutable('2026-06-01'), 33.0),
+        ];
+    }
+}

--- a/tests/ComplexityReport/Trend/TrendWindowTest.php
+++ b/tests/ComplexityReport/Trend/TrendWindowTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\ComplexityReport\Trend;
+
+use App\ComplexityReport\Trend\TrendWindow;
+use PHPUnit\Framework\TestCase;
+
+final class TrendWindowTest extends TestCase
+{
+    /**
+     * @dataProvider starts
+     */
+    public function testItKnowsWhenItOpened(TrendWindow $window, ?string $expected): void
+    {
+        $start = $window->startedAt(new \DateTimeImmutable('2026-07-31 12:34:56'));
+
+        self::assertSame($expected, $start?->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @return iterable<string, array{TrendWindow, string|null}>
+     */
+    public static function starts(): iterable
+    {
+        // year to date opens on new year's day, not twelve hours into it
+        yield 'year to date' => [TrendWindow::YearToDate, '2026-01-01 00:00:00'];
+        yield 'twelve months' => [TrendWindow::TwelveMonths, '2025-07-31 12:34:56'];
+        yield 'five years' => [TrendWindow::FiveYears, '2021-07-31 12:34:56'];
+        // all time has no date every library shares - it starts at their own first release
+        yield 'all time' => [TrendWindow::AllTime, null];
+    }
+
+    public function testTheTurnOfTheYearLeavesYearToDateWithoutADayInIt(): void
+    {
+        $start = TrendWindow::YearToDate->startedAt(new \DateTimeImmutable('2026-01-01 00:30:00'));
+
+        self::assertSame('2026-01-01 00:00:00', $start?->format('Y-m-d H:i:s'));
+    }
+
+    public function testALeapDayStillFindsItsWindowAYearBack(): void
+    {
+        $start = TrendWindow::TwelveMonths->startedAt(new \DateTimeImmutable('2024-02-29 00:00:00'));
+
+        self::assertSame('2023-03-01 00:00:00', $start?->format('Y-m-d H:i:s'));
+    }
+
+    public function testEveryWindowIsNamed(): void
+    {
+        foreach (TrendWindow::all() as $window) {
+            self::assertNotSame('', $window->label());
+            self::assertNotSame('', $window->title());
+        }
+    }
+
+    public function testTheWindowsAreOfferedShortestFirst(): void
+    {
+        self::assertSame(
+            [TrendWindow::YearToDate, TrendWindow::TwelveMonths, TrendWindow::FiveYears, TrendWindow::AllTime],
+            TrendWindow::all()
+        );
+    }
+}


### PR DESCRIPTION
The hero states how much the report carries, but never what all of it did. It now closes on a single figure on the right: how the average complexity of every tracked library changed, over the time frame the switch below it picks — **YTD**, **12M**, **5Y**, **all time**.

Against the local dataset (5 analysed libraries, 115 releases): YTD `↓ −8.9%`, 12 months `↓ −11.8%`, 5 years `↓ −11.2%`, all time `↑ +16.7%`.

### What the number means

Two rules keep it honest, both in `TrendCalculator`:

- **Only libraries that were already measured when the window opened take part in it.** Otherwise submitting a repository today would move the five year figure, although nothing about its code changed — that would be the dataset growing, not the code getting hairier.
- **Every library counts once**, weighted neither by releases nor by size, represented by the release it stood at when the window opened. One that has not released since carries its last measurement forward, which is what its chart shows as well.

All time has no date the libraries share, so it compares each of them against its own first release.

### Shape

- `TrendWindow` — the four time frames and when they opened.
- `ReleasePoint` / `Trend` — what goes in, what comes out.
- `TrendCalculator` — pure: a list of points plus the current time in, value objects out. No entity, no database, no clock, so every rule above is unit tested (`TrendCalculatorTest`, `TrendWindowTest` — 20 cases).
- `TrendLoader` — the only part that touches storage: one query (`TagRepository::findReleasePoints()`, scalar, no hydration), cached in `cache.app` for an hour under a key that carries the day, since the windows move with it.
- `trend_controller.js` — all four figures are rendered with the request, picking one only swaps which is visible.

Without javascript the year to date figure is the one that stands; a report that has nothing analysed yet keeps the mark that used to close the hero.

### Checks

`composer validate`, `lint:yaml`, `lint:twig`, `lint:container`, `doctrine:schema:validate --skip-sync`, php-cs-fixer, phpstan (level 8), phpunit (75 tests), prettier — all green. Rendered against the local database and clicked through all four time frames in a headless browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)