### PR TITLE
Bound what a submitted repository may cost

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,8 +102,11 @@ used to carry came from optional profile fields and named the wrong account as o
 - `GitHub/GitHubClient` — the only external source, wraps `api.github.com` (repository, owner, languages)
   behind a 1h cache. `GitHub/RepositoryIdentifier::fromInput()` parses everything users may paste
   (`owner/repo`, https/ssh urls, deep links) and rejects any host but github.com.
-- `RepositorySubmitter` — validates a submission (unknown, fork, empty, less than `MIN_PHP_SHARE` PHP),
-  creates the `Organization` for its owner on the fly and dispatches `AnalyseRepository`. Rejections are
+- `RepositorySubmitter` — validates a submission (unknown, fork, empty, larger than `MAX_SIZE`, less than
+  `MIN_PHP_SHARE` PHP) and refuses everything while `MAX_PENDING` repositories are already waiting for a
+  worker — the submitter picks what gets cloned, so what a submission may cost is capped before it is
+  queued rather than after. It then creates the `Organization` for its owner on the fly and dispatches
+  `AnalyseRepository`. Rejections are
   `Exception\SubmissionFailed`, whose messages are written to be shown to the submitter. A repository the
   report already carries is **not** one of them: `submit()` returns a `Submission` that says whether this
   submission is what queued it, so pasting a known repository is how people look it up — it is answered
@@ -117,11 +120,17 @@ used to carry came from optional profile fields and named the wrong account as o
   retry only redoes what is left, then `markAnalysed()`. It does **not** guard the working copy — that is
   the handler's job.
 - `Git` / `GitController` / `CodeAnalyser` — `Git` shells out via symfony/process and logs every call on the
-  `git` monolog channel; it pins `GIT_TERMINAL_PROMPT=0` so a repository that went private fails instead of
-  blocking a worker on a credential prompt. `GitController` adds the domain layer (clone on first use, load
-  tags local and remote, checkout, last commit date, remove/list working copies). Metrics come from phploc's
-  `Analyser` (`loc`, `classCcnAvg`). Both receive the `$repositoryPath` bound globally in
-  `config/services.yaml`.
+  `git` monolog channel; it passes arguments as a list (never a shell line), pins `GIT_TERMINAL_PROMPT=0` so
+  a repository that went private fails instead of blocking a worker on a credential prompt, and gives every
+  call a `TIMEOUT` so a remote that stalls mid-transfer cannot hold that worker forever. `GitController`
+  adds the domain layer (clone on first use, load tags local and remote, checkout under the full
+  `refs/tags/` ref, last commit date, remove/list working copies). Metrics come from phploc's `Analyser`
+  (`loc`, `classCcnAvg`). Both receive the `$repositoryPath` bound globally in `config/services.yaml`.
+- `SourceFiles` — which files of a working copy phploc is handed. A submitted repository decides what its
+  own files are and git stores a symlink like any other file, so this drops what leaves the working copy
+  (`evil.php -> /dev/zero` reads until the worker is out of memory, a link to a file elsewhere would be
+  counted into the report) and what is too large to be source code. Links **within** the copy are ordinary
+  and stay.
 - `WorkingCopyLock` — one lock per repository, taken by everything that touches its working copy.
 - `DataFixer` + `DataFixer/*Fixer` — post-processing for datasets where git history lies (Laminas tags all
   dated at the Zend→Laminas import, PHPUnit tags with a bogus 2006 date, Laravel minors that distort the
@@ -143,13 +152,20 @@ shared working copy, so a second worker on the same repository would silently me
 busy repository throws `RecoverableMessageHandlingException` and is retried — deliberately without
 consuming the retry budget, since being busy is not a failure.
 
-**Submitting** is the only write the web exposes, so `submit` checks a CSRF token before anything else and
-then spends one token of the `submission` rate limiter (5 per 15 minutes and IP). CSRF is **stateless**
-(`config/packages/csrf.yaml`): the token is a double submit cookie written by Symfony's `csrf-protection`
-Stimulus controller, which is why the hidden field carries `data-controller="csrf-protection"` and why
-reading the report never starts a session. Both rejections are flashes, not exceptions - a human mistyping
-twice should not get an error page. Anything that gets through ends on the page of its repository, whether
-it was just queued or has been in the report for years.
+**Submitting** is the only write the web exposes, so `submit` spends one token of the `submission` rate
+limiter (5 per 15 minutes and IP) before anything else and only then checks the CSRF token - the limiter
+comes first because a request without a token costs something too, and this way a script cannot send more
+of them than a visitor may send submissions. CSRF is **stateless** (`config/packages/csrf.yaml`): the token
+is a double submit cookie written by Symfony's `csrf-protection` Stimulus controller, which is why the
+hidden field carries `data-controller="csrf-protection"`, and a browser without javascript still passes on
+the same-origin check. It is a cross-site guard, not a bot guard - the rate limiter is what bounds the
+work.
+
+Reading the report never starts a session, and these two refusals must not either: a flash writes a
+session, so `refuse()` answers them with a plain `429`/`400` instead. Everything a *visitor* runs into -
+an unknown repository, a fork, too little PHP - stays a flash on the start page, redirected to with the
+303 turbo needs, because a human mistyping twice should not get an error page. Anything that gets through
+ends on the page of its repository, whether it was just queued or has been in the report for years.
 
 **Web** (`src/Controller/ReportController`) — routes are distinguished by `priority`, since
 `{organization}` and `{id}` both match a single segment: `overview`/`submit` (3) > `repository` (2, digits

--- a/src/ComplexityReport/CodeAnalyser.php
+++ b/src/ComplexityReport/CodeAnalyser.php
@@ -6,13 +6,12 @@ namespace App\ComplexityReport;
 
 use App\Entity\Repository;
 use SebastianBergmann\PHPLOC\Analyser;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 
 final class CodeAnalyser
 {
     public function __construct(
         private GitController $gitController,
+        private SourceFiles $sourceFiles,
         private string $repositoryPath,
     ) {
     }
@@ -20,14 +19,7 @@ final class CodeAnalyser
     public function analyse(Repository $repository): Analysis
     {
         $localPath = $this->repositoryPath.'/'.$repository->getLocalPath();
-        $finder = (new Finder())
-            ->files()
-            ->in($localPath)
-            ->name('*.php');
-
-        $files = array_map(static function (SplFileInfo $file) {
-            return $file->getRealPath();
-        }, iterator_to_array($finder));
+        $files = $this->sourceFiles->collect($localPath, $repository->getName());
 
         $analysis = (new Analyser())->countFiles($files, false);
 

--- a/src/ComplexityReport/Exception/SubmissionFailed.php
+++ b/src/ComplexityReport/Exception/SubmissionFailed.php
@@ -9,11 +9,17 @@ namespace App\ComplexityReport\Exception;
  */
 final class SubmissionFailed extends \RuntimeException
 {
+    /**
+     * How much of a rejected input is quoted back. Enough to recognise what was pasted - the message ends
+     * up in a flash, and whatever was sent is not worth carrying through a session for.
+     */
+    private const int QUOTED_INPUT_LENGTH = 120;
+
     public static function invalidInput(string $input): self
     {
         return new self(sprintf(
             'Cannot read a GitHub repository from "%s" - please use the format owner/repository.',
-            $input
+            self::quote($input)
         ));
     }
 
@@ -42,6 +48,16 @@ final class SubmissionFailed extends \RuntimeException
         return new self(sprintf('Repository %s is empty.', $identifier));
     }
 
+    public static function oversizedRepository(string $identifier, int $sizeInKilobytes, int $limitInKilobytes): self
+    {
+        return new self(sprintf(
+            'Repository %s is %d MB and too large to analyse - the limit is %d MB.',
+            $identifier,
+            intdiv($sizeInKilobytes, 1024),
+            intdiv($limitInKilobytes, 1024)
+        ));
+    }
+
     public static function gitHubUnavailable(string $identifier, \Throwable $previous): self
     {
         return new self(
@@ -49,5 +65,19 @@ final class SubmissionFailed extends \RuntimeException
             0,
             $previous
         );
+    }
+
+    public static function tooManySubmissions(): self
+    {
+        return new self('The report is taking in more repositories than it can measure right now - please try again later.');
+    }
+
+    private static function quote(string $input): string
+    {
+        if (mb_strlen($input) <= self::QUOTED_INPUT_LENGTH) {
+            return $input;
+        }
+
+        return mb_substr($input, 0, self::QUOTED_INPUT_LENGTH).'...';
     }
 }

--- a/src/ComplexityReport/Git.php
+++ b/src/ComplexityReport/Git.php
@@ -9,6 +9,15 @@ use Symfony\Component\Process\Process;
 
 final readonly class Git
 {
+    /**
+     * How long a single git call may take, in seconds.
+     *
+     * Cloning a large repository is a matter of minutes, so this is generous - it is not there to keep
+     * git quick but to end the calls that never finish at all: a remote that accepts the connection and
+     * then stalls would otherwise hold a worker until someone notices.
+     */
+    private const int TIMEOUT = 1800;
+
     public function __construct(
         private LoggerInterface $gitLogger,
     ) {
@@ -16,7 +25,8 @@ final readonly class Git
 
     public function cloneRepository(string $url, string $path): void
     {
-        $this->run(null, 'clone', $url, $path);
+        // `--` so a url can never be read as an option, whatever github.com reports it as
+        $this->run(null, 'clone', '--', $url, $path);
     }
 
     /**
@@ -34,7 +44,7 @@ final readonly class Git
      */
     public function listRemoteTags(string $url): array
     {
-        return $this->lines($this->run(null, 'ls-remote', '--tags', '--refs', $url));
+        return $this->lines($this->run(null, 'ls-remote', '--tags', '--refs', '--', $url));
     }
 
     /**
@@ -54,7 +64,7 @@ final readonly class Git
         // a repository that went private or was deleted must fail instead of waiting for credentials
         // that a worker process can never provide
         $process = new Process(['git', ...$arguments], $workingDirectory, ['GIT_TERMINAL_PROMPT' => '0']);
-        $process->setTimeout(null);
+        $process->setTimeout(self::TIMEOUT);
 
         return $process->mustRun()->getOutput();
     }

--- a/src/ComplexityReport/GitController.php
+++ b/src/ComplexityReport/GitController.php
@@ -39,9 +39,13 @@ final readonly class GitController
         return GitTag::fromRefs($this->git->listRemoteTags($repository->getCloneUrl()));
     }
 
+    /**
+     * A tag is checked out under its full ref: what is measured should be the tag and never a branch that
+     * happens to share its name, and a ref spelled out this way cannot be read as an option either.
+     */
     public function checkoutTag(Repository $repository, string $name): void
     {
-        $this->git->run($this->getLocalPath($repository), 'checkout', '--force', $name);
+        $this->git->run($this->getLocalPath($repository), 'checkout', '--force', sprintf('refs/tags/%s', $name));
     }
 
     /**

--- a/src/ComplexityReport/GitHub/GitHubClient.php
+++ b/src/ComplexityReport/GitHub/GitHubClient.php
@@ -147,12 +147,15 @@ final class GitHubClient
     }
 
     /**
-     * `|` rather than `_`, which is a character a repository may be named with: `/repos/a/b/languages`
-     * and `/repos/a/b_languages` are two different requests and used to share one cache entry, so one
-     * of them was answered with the other one's response.
+     * The path is hashed rather than spelled out.
+     *
+     * A repository may be named with every character a path could be joined by, so `/repos/a/b/languages`
+     * and `/repos/a/b_languages` used to share one entry and one of them was answered with the other one's
+     * response. A hash cannot collide by naming, and it stays within the characters PSR-6 asks a pool to
+     * accept - which the separator that would read nicer here does not.
      */
     private function cacheKey(string $path): string
     {
-        return 'github|'.str_replace('/', '|', trim($path, '/'));
+        return 'github_'.hash('xxh128', trim($path, '/'));
     }
 }

--- a/src/ComplexityReport/GitHub/GitHubClient.php
+++ b/src/ComplexityReport/GitHub/GitHubClient.php
@@ -16,9 +16,23 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class GitHubClient
 {
-    private const API_URL = 'https://api.github.com';
-    private const CACHE_TTL = 3600;
-    private const LOG_RESPONSE_LENGTH = 500;
+    private const string API_URL = 'https://api.github.com';
+    private const int CACHE_TTL = 3600;
+    private const int LOG_RESPONSE_LENGTH = 500;
+
+    /**
+     * A name github.com does not know is remembered too, and for much shorter.
+     *
+     * The api quota is what the whole report runs on, and a request for a repository that does not exist
+     * spends it just like any other - so asking for names that never existed must not be free. Short,
+     * because a repository that gets created should not stay unknown for the rest of the hour.
+     */
+    private const int MISSING_CACHE_TTL = 300;
+
+    /**
+     * Marks a cached miss. Not a field github.com sends, so it cannot be one of its own answers.
+     */
+    private const string MISSING = '__not_found';
 
     public function __construct(
         private HttpClientInterface $httpClient,
@@ -71,13 +85,19 @@ final class GitHubClient
         }
 
         if (!$item->isHit()) {
-            $item->set($this->fetch($path, (string) $subject));
-            $item->expiresAfter(self::CACHE_TTL);
+            $fetched = $this->fetch($path, (string) $subject);
+
+            $item->set($fetched);
+            $item->expiresAfter(isset($fetched[self::MISSING]) ? self::MISSING_CACHE_TTL : self::CACHE_TTL);
             $this->cache->save($item);
         }
 
         /** @var array<string, mixed> $data */
         $data = $item->get();
+
+        if (isset($data[self::MISSING])) {
+            throw SubmissionFailed::unknownRepository((string) $subject);
+        }
 
         return $data;
     }
@@ -103,7 +123,7 @@ final class GitHubClient
             $response = $exception->getResponse();
 
             if (404 === $response->getStatusCode()) {
-                throw SubmissionFailed::unknownRepository($subject);
+                return [self::MISSING => true];
             }
 
             // Whoever submitted the repository is told to try again later, but a refusal is rarely
@@ -126,8 +146,13 @@ final class GitHubClient
         }
     }
 
+    /**
+     * `|` rather than `_`, which is a character a repository may be named with: `/repos/a/b/languages`
+     * and `/repos/a/b_languages` are two different requests and used to share one cache entry, so one
+     * of them was answered with the other one's response.
+     */
     private function cacheKey(string $path): string
     {
-        return 'github_'.str_replace('/', '_', trim($path, '/'));
+        return 'github|'.str_replace('/', '|', trim($path, '/'));
     }
 }

--- a/src/ComplexityReport/GitHub/RepositoryData.php
+++ b/src/ComplexityReport/GitHub/RepositoryData.php
@@ -14,6 +14,10 @@ final class RepositoryData
         public readonly int $stars,
         public readonly bool $fork,
         public readonly bool $empty,
+        /**
+         * Size of the repository in kilobytes, as github.com reports it - what a clone roughly costs.
+         */
+        public readonly int $size = 0,
     ) {
     }
 
@@ -25,6 +29,7 @@ final class RepositoryData
         /** @var array{login: string} $owner */
         $owner = $data['owner'];
         $identifier = new RepositoryIdentifier($owner['login'], (string) $data['name']);
+        $size = (int) $data['size'];
 
         return new self(
             $identifier,
@@ -33,7 +38,8 @@ final class RepositoryData
             null !== $data['description'] ? (string) $data['description'] : null,
             (int) $data['stargazers_count'],
             (bool) $data['fork'],
-            0 === (int) $data['size'],
+            0 === $size,
+            $size,
         );
     }
 }

--- a/src/ComplexityReport/GitHub/RepositoryIdentifier.php
+++ b/src/ComplexityReport/GitHub/RepositoryIdentifier.php
@@ -14,7 +14,9 @@ final class RepositoryIdentifier implements \Stringable
     private const string SEGMENT_PATTERN = '#^[A-Za-z0-9._-]+$#';
 
     /**
-     * github.com caps an account at 39 and a repository at 100 characters.
+     * One cap for both segments, at the longer of the two limits github.com has - an account may be 39
+     * characters, a repository 100. Telling them apart would not buy anything: what matters is that a
+     * segment has a length at all, not which of the two is stricter.
      */
     private const int MAX_SEGMENT_LENGTH = 100;
 

--- a/src/ComplexityReport/GitHub/RepositoryIdentifier.php
+++ b/src/ComplexityReport/GitHub/RepositoryIdentifier.php
@@ -11,13 +11,31 @@ use App\ComplexityReport\Exception\SubmissionFailed;
  */
 final class RepositoryIdentifier implements \Stringable
 {
-    private const SEGMENT_PATTERN = '#^[A-Za-z0-9._-]+$#';
+    private const string SEGMENT_PATTERN = '#^[A-Za-z0-9._-]+$#';
+
+    /**
+     * github.com caps an account at 39 and a repository at 100 characters.
+     */
+    private const int MAX_SEGMENT_LENGTH = 100;
+
+    /**
+     * Long enough for the deepest github.com url a repository can be pasted as, and short enough that
+     * nothing downstream has to carry a payload - the input is quoted back in the rejection message.
+     */
+    private const int MAX_INPUT_LENGTH = 2048;
+
+    /**
+     * Segments that name a directory rather than a repository. A path is built from these (the working
+     * copy) and so is a github.com api url, where `..` is resolved away before the request is sent - so
+     * `owner/..` would ask for something else entirely.
+     */
+    private const array RESERVED_SEGMENTS = ['.', '..'];
 
     public function __construct(
         public readonly string $owner,
         public readonly string $name,
     ) {
-        if (1 !== preg_match(self::SEGMENT_PATTERN, $owner) || 1 !== preg_match(self::SEGMENT_PATTERN, $name)) {
+        if (!self::isValidSegment($owner) || !self::isValidSegment($name)) {
             throw SubmissionFailed::invalidInput(sprintf('%s/%s', $owner, $name));
         }
     }
@@ -28,6 +46,10 @@ final class RepositoryIdentifier implements \Stringable
      */
     public static function fromInput(string $input): self
     {
+        if (mb_strlen($input) > self::MAX_INPUT_LENGTH) {
+            throw SubmissionFailed::invalidInput($input);
+        }
+
         $normalized = trim($input);
         $normalized = preg_replace('#^(https?://|ssh://|git@)#i', '', $normalized) ?? $normalized;
         $normalized = str_replace('github.com:', 'github.com/', $normalized);
@@ -54,5 +76,12 @@ final class RepositoryIdentifier implements \Stringable
     public function __toString(): string
     {
         return sprintf('%s/%s', $this->owner, $this->name);
+    }
+
+    private static function isValidSegment(string $segment): bool
+    {
+        return 1 === preg_match(self::SEGMENT_PATTERN, $segment)
+            && mb_strlen($segment) <= self::MAX_SEGMENT_LENGTH
+            && !in_array($segment, self::RESERVED_SEGMENTS, true);
     }
 }

--- a/src/ComplexityReport/RepositorySearch.php
+++ b/src/ComplexityReport/RepositorySearch.php
@@ -22,6 +22,12 @@ final readonly class RepositorySearch
      */
     private const int MIN_LENGTH = 2;
 
+    /**
+     * Above the longest `owner/repository` github.com can hold, nothing is being looked up - and the box
+     * is answered without asking the database to match a query nobody typed.
+     */
+    private const int MAX_LENGTH = 200;
+
     public function __construct(private RepositoryRepository $repositories)
     {
     }
@@ -29,8 +35,9 @@ final readonly class RepositorySearch
     public function search(string $input, int $limit): SearchResult
     {
         $query = trim($input);
+        $length = mb_strlen($query);
 
-        if (mb_strlen($query) < self::MIN_LENGTH) {
+        if ($length < self::MIN_LENGTH || $length > self::MAX_LENGTH) {
             return new SearchResult([]);
         }
 

--- a/src/ComplexityReport/RepositorySubmitter.php
+++ b/src/ComplexityReport/RepositorySubmitter.php
@@ -24,7 +24,25 @@ final class RepositorySubmitter
     /**
      * Repositories don't need a composer.json, but they need to be mostly written in PHP.
      */
-    private const MIN_PHP_SHARE = 0.2;
+    private const float MIN_PHP_SHARE = 0.2;
+
+    /**
+     * Largest repository that is still worth cloning, in kilobytes - the unit github.com reports.
+     *
+     * Analysing means cloning the full history into a shared directory, and the submitter picks what
+     * lands there. Two gigabytes is far above what the source of a PHP project weighs and still bounds
+     * what a single submission can cost the disk.
+     */
+    private const int MAX_SIZE = 2 * 1024 * 1024;
+
+    /**
+     * How many repositories may wait for their first analysis at once.
+     *
+     * Every submission ends in a clone, and the queue is drained by a worker that measures one release
+     * after another. Past this the report is not losing anything by asking people to come back later -
+     * whoever fills the queue does not get to fill the disk with it.
+     */
+    private const int MAX_PENDING = 50;
 
     public function __construct(
         private GitHubClient $client,
@@ -63,6 +81,15 @@ final class RepositorySubmitter
 
         if ($data->empty) {
             throw SubmissionFailed::emptyRepository($identifier);
+        }
+
+        if ($data->size > self::MAX_SIZE) {
+            throw SubmissionFailed::oversizedRepository($identifier, $data->size, self::MAX_SIZE);
+        }
+
+        // asked once the repository itself is worth taking, so a full queue costs no further api quota
+        if ($this->repositoryRepository->countPending() >= self::MAX_PENDING) {
+            throw SubmissionFailed::tooManySubmissions();
         }
 
         if ($this->client->getPhpShare($data->identifier) < self::MIN_PHP_SHARE) {

--- a/src/ComplexityReport/SourceFiles.php
+++ b/src/ComplexityReport/SourceFiles.php
@@ -60,8 +60,16 @@ final readonly class SourceFiles
                 continue;
             }
 
-            if (filesize($path) > self::MAX_FILE_SIZE) {
-                $this->skip($candidate->getRelativePathname(), $repositoryName, 'it is too large to measure');
+            $size = filesize($path);
+
+            // a size that cannot be read is not a small file - this list decides what is read into
+            // memory, so what it cannot measure it leaves out
+            if (false === $size || $size > self::MAX_FILE_SIZE) {
+                $this->skip(
+                    $candidate->getRelativePathname(),
+                    $repositoryName,
+                    false === $size ? 'its size cannot be read' : 'it is too large to measure'
+                );
 
                 continue;
             }

--- a/src/ComplexityReport/SourceFiles.php
+++ b/src/ComplexityReport/SourceFiles.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * The PHP files of a working copy that may be measured.
+ *
+ * A submitted repository decides what its own files are, and git stores a symlink as faithfully as it
+ * stores source code - `evil.php -> /dev/zero` is a perfectly valid commit. Whatever ends up in this list
+ * is read into memory as a whole, so the list is what keeps a repository from reading the machine it is
+ * measured on: everything the checkout put inside the working copy, and nothing else.
+ */
+final readonly class SourceFiles
+{
+    /**
+     * Source files are measured as a whole, in memory - past a few megabytes it is generated data, not
+     * code someone wrote, and not worth the memory of the worker that reads it.
+     */
+    private const int MAX_FILE_SIZE = 4 * 1024 * 1024;
+
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function collect(string $workingCopy, string $repositoryName): array
+    {
+        $root = realpath($workingCopy);
+
+        if (false === $root || !is_dir($root)) {
+            return [];
+        }
+
+        $finder = (new Finder())
+            ->files()
+            ->in($root)
+            ->name('*.php');
+
+        $files = [];
+
+        foreach ($finder as $candidate) {
+            $path = realpath($candidate->getPathname());
+
+            // a link to nowhere resolves to nothing, and a character device is not a regular file -
+            // reading one of those would go on until the worker is out of memory
+            if (false === $path || !is_file($path)) {
+                continue;
+            }
+
+            if (!str_starts_with($path, $root.\DIRECTORY_SEPARATOR)) {
+                $this->skip($candidate->getRelativePathname(), $repositoryName, sprintf('it points at %s', $path));
+
+                continue;
+            }
+
+            if (filesize($path) > self::MAX_FILE_SIZE) {
+                $this->skip($candidate->getRelativePathname(), $repositoryName, 'it is too large to measure');
+
+                continue;
+            }
+
+            $files[] = $path;
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    private function skip(string $file, string $repositoryName, string $reason): void
+    {
+        $this->logger->warning(sprintf('Skipping %s of %s, %s', $file, $repositoryName, $reason));
+    }
+}

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -84,8 +84,9 @@ final class ReportController extends AbstractController
     }
 
     /**
-     * Every answer to the form is a redirect, and every one of them says 303: turbo follows the answer
-     * to a submission itself, and only a See Other tells it to read the page that follows with a GET.
+     * Every answer a visitor gets is a redirect, and every one of them says 303: turbo follows the answer
+     * to a submission itself, and only a See Other tells it to read the page that follows with a GET. The
+     * two refusals below are the exception - see refuse().
      */
     #[Route('submit', name: 'submit', methods: 'POST', priority: 3)]
     public function submit(
@@ -93,17 +94,20 @@ final class ReportController extends AbstractController
         RepositorySubmitter $submitter,
         RateLimiterFactoryInterface $submissionLimiter,
     ): Response {
-        if (!$this->isCsrfTokenValid('submit', (string) $request->request->get('_token'))) {
-            $this->addFlash('danger', 'That form expired - please submit the repository again.');
+        // every submission spends github.com API quota and ends in a clone, so it is worth a limit -
+        // and it is spent before anything else, because the checks below are not free either
+        $limit = $submissionLimiter->create($request->getClientIp())->consume();
 
-            return $this->redirectToRoute('start', status: Response::HTTP_SEE_OTHER);
+        if (!$limit->isAccepted()) {
+            return $this->refuse(
+                'That is a lot of repositories at once - please try again in a few minutes.',
+                Response::HTTP_TOO_MANY_REQUESTS,
+                ['Retry-After' => max(0, $limit->getRetryAfter()->getTimestamp() - time())]
+            );
         }
 
-        // every submission spends github.com API quota and ends in a clone, so it is worth a limit
-        if (!$submissionLimiter->create($request->getClientIp())->consume()->isAccepted()) {
-            $this->addFlash('danger', 'That is a lot of repositories at once - please try again in a few minutes.');
-
-            return $this->redirectToRoute('start', status: Response::HTTP_SEE_OTHER);
+        if (!$this->isCsrfTokenValid('submit', (string) $request->request->get('_token'))) {
+            return $this->refuse('That form expired - please submit the repository again.', Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -150,6 +154,21 @@ final class ReportController extends AbstractController
     public function repository(#[MapEntity(mapping: ['id' => 'id'])] Repository $repository): JsonResponse
     {
         return new JsonResponse($repository->asGraph()->getTagData());
+    }
+
+    /**
+     * A refusal that never touches the session.
+     *
+     * Every other answer to a submission is a flash on the start page, which is what a human should read.
+     * A flash starts a session though, and these two refusals are the ones a script runs into rather than
+     * a visitor: a request over the limit, and one without a token. Answering those with a flash would
+     * write a session per request, for as many requests as someone cares to send.
+     *
+     * @param array<string, int|string> $headers
+     */
+    private function refuse(string $message, int $status, array $headers = []): Response
+    {
+        return new Response($message, $status, $headers + ['Content-Type' => 'text/plain; charset=UTF-8']);
     }
 
     /**

--- a/src/Repository/RepositoryRepository.php
+++ b/src/Repository/RepositoryRepository.php
@@ -103,6 +103,18 @@ final class RepositoryRepository extends ServiceEntityRepository
     }
 
     /**
+     * How much work is waiting - counted rather than loaded, the submitter only needs the number.
+     */
+    public function countPending(): int
+    {
+        return (int) $this->createQueryBuilder('r')
+            ->select('COUNT(r.id)')
+            ->where('r.analysed IS NULL')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
      * Submitted repositories that are waiting for their first analysis.
      *
      * @return list<Repository>

--- a/tests/ComplexityReport/GitHub/GitHubClientTest.php
+++ b/tests/ComplexityReport/GitHub/GitHubClientTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\ComplexityReport\GitHub;
+
+use App\ComplexityReport\Exception\SubmissionFailed;
+use App\ComplexityReport\GitHub\GitHubClient;
+use App\ComplexityReport\GitHub\RepositoryIdentifier;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class GitHubClientTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $requested = [];
+
+    /**
+     * `/repos/a/b/languages` and `/repos/a/b_languages` are two different requests - a repository may be
+     * named with the character the parts of a path are joined by, so they must not share a cache entry.
+     */
+    public function testTwoPathsThatReadAlikeAreCachedApart(): void
+    {
+        $client = $this->client();
+
+        $client->getPhpShare(RepositoryIdentifier::fromInput('a/b'));
+        $repository = $client->getRepository(RepositoryIdentifier::fromInput('a/b_languages'));
+
+        self::assertSame(['/repos/a/b/languages', '/repos/a/b_languages'], $this->requested);
+        self::assertSame('a/b_languages', (string) $repository->identifier);
+    }
+
+    public function testItAsksOnceForTheSameRepository(): void
+    {
+        $client = $this->client();
+        $identifier = RepositoryIdentifier::fromInput('a/b');
+
+        $client->getRepository($identifier);
+        $client->getRepository($identifier);
+
+        self::assertSame(['/repos/a/b'], $this->requested);
+    }
+
+    /**
+     * A name github.com does not know spends the api quota like any other - so it is remembered too.
+     */
+    public function testItRemembersThatARepositoryDoesNotExist(): void
+    {
+        $client = $this->client(missing: true);
+        $identifier = RepositoryIdentifier::fromInput('nobody/nothing');
+
+        for ($attempt = 1; $attempt <= 3; ++$attempt) {
+            try {
+                $client->getRepository($identifier);
+                self::fail('Expected the repository to be rejected as unknown.');
+            } catch (SubmissionFailed $exception) {
+                self::assertStringContainsString('nobody/nothing', $exception->getMessage());
+            }
+        }
+
+        self::assertSame(['/repos/nobody/nothing'], $this->requested);
+    }
+
+    private function client(bool $missing = false): GitHubClient
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) use ($missing): MockResponse {
+            $path = (string) parse_url($url, \PHP_URL_PATH);
+            $this->requested[] = $path;
+
+            if ($missing) {
+                return new MockResponse('{"message": "Not Found"}', ['http_code' => 404]);
+            }
+
+            if (str_ends_with($path, '/languages')) {
+                return new MockResponse((string) json_encode(['PHP' => 100]));
+            }
+
+            return new MockResponse((string) json_encode([
+                'name' => basename($path),
+                'owner' => ['login' => 'a'],
+                'html_url' => 'https://github.com'.$path,
+                'clone_url' => 'https://github.com'.$path.'.git',
+                'description' => null,
+                'stargazers_count' => 1,
+                'fork' => false,
+                'size' => 42,
+            ]));
+        });
+
+        return new GitHubClient($httpClient, new ArrayAdapter(), '', new NullLogger());
+    }
+}

--- a/tests/ComplexityReport/GitHub/RepositoryDataTest.php
+++ b/tests/ComplexityReport/GitHub/RepositoryDataTest.php
@@ -29,6 +29,8 @@ final class RepositoryDataTest extends TestCase
         self::assertSame(9678, $data->stars);
         self::assertFalse($data->fork);
         self::assertFalse($data->empty);
+        // what a clone of it roughly costs, which is why it is carried at all
+        self::assertSame(4711, $data->size);
     }
 
     public function testItDetectsEmptyRepositoriesAndMissingDescriptions(): void

--- a/tests/ComplexityReport/GitHub/RepositoryIdentifierTest.php
+++ b/tests/ComplexityReport/GitHub/RepositoryIdentifierTest.php
@@ -34,6 +34,8 @@ final class RepositoryIdentifierTest extends TestCase
         yield 'ssh url' => ['git@github.com:symfony/console.git', 'symfony/console'];
         yield 'deep link' => ['https://github.com/symfony/console/tree/6.3', 'symfony/console'];
         yield 'dots and dashes' => ['WordPress/WordPress-Coding-Standards', 'WordPress/WordPress-Coding-Standards'];
+        // a leading dot is a repository name github.com hands out, `.github` being the common one
+        yield 'name starting with a dot' => ['symfony/.github', 'symfony/.github'];
     }
 
     /**
@@ -57,5 +59,25 @@ final class RepositoryIdentifierTest extends TestCase
         yield 'missing repository' => ['symfony/'];
         yield 'another host' => ['https://gitlab.com/inkscape'];
         yield 'invalid characters' => ['symfony/console;rm -rf'];
+        // `..` names a directory, not a repository: it would walk out of the working copy it is cloned
+        // into, and the api url it is put into resolves it away before the request is sent
+        yield 'parent directory as name' => ['symfony/..'];
+        yield 'current directory as name' => ['symfony/.'];
+        yield 'traversal in a url' => ['https://github.com/symfony/../../users/fabpot'];
+        yield 'longer than github.com allows' => ['symfony/'.str_repeat('a', 101)];
+        yield 'longer than anything that could be a repository' => [str_repeat('a', 3000).'/console'];
+    }
+
+    /**
+     * The rejection quotes the input back at the submitter, so it must not quote back a payload.
+     */
+    public function testItDoesNotCarryAnOversizedInputIntoItsMessage(): void
+    {
+        try {
+            RepositoryIdentifier::fromInput(str_repeat('x', 5000));
+            self::fail('Expected the input to be rejected.');
+        } catch (SubmissionFailed $exception) {
+            self::assertLessThan(300, mb_strlen($exception->getMessage()));
+        }
     }
 }

--- a/tests/ComplexityReport/SourceFilesTest.php
+++ b/tests/ComplexityReport/SourceFilesTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\ComplexityReport;
+
+use App\ComplexityReport\SourceFiles;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class SourceFilesTest extends TestCase
+{
+    private string $workingCopy;
+    private string $outside;
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $base = sys_get_temp_dir().'/source-files-'.bin2hex(random_bytes(6));
+
+        $this->workingCopy = $base.'/working-copy';
+        $this->outside = $base.'/outside';
+
+        $this->filesystem->mkdir([$this->workingCopy.'/src', $this->outside]);
+        $this->filesystem->dumpFile($this->workingCopy.'/src/code.php', '<?php class A {}');
+        $this->filesystem->dumpFile($this->outside.'/secret.php', '<?php // none of our business');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove(\dirname($this->workingCopy));
+    }
+
+    public function testItCollectsThePhpFilesOfTheWorkingCopy(): void
+    {
+        $this->filesystem->dumpFile($this->workingCopy.'/README.md', 'not php');
+
+        self::assertSame([realpath($this->workingCopy.'/src/code.php')], $this->collect());
+    }
+
+    /**
+     * `evil.php -> /dev/zero` is a commit git stores and checks out like any other, and phploc reads what
+     * it is handed - so the file it points at has to be excluded before it is read, not while.
+     */
+    public function testItSkipsALinkToACharacterDevice(): void
+    {
+        if (!file_exists('/dev/zero')) {
+            self::markTestSkipped('No character device to point at.');
+        }
+
+        $this->filesystem->symlink('/dev/zero', $this->workingCopy.'/evil.php');
+
+        self::assertNotContains($this->workingCopy.'/evil.php', $this->collect());
+        self::assertCount(1, $this->collect());
+    }
+
+    public function testItSkipsALinkOutOfTheWorkingCopy(): void
+    {
+        $this->filesystem->symlink($this->outside.'/secret.php', $this->workingCopy.'/leak.php');
+
+        self::assertSame([realpath($this->workingCopy.'/src/code.php')], $this->collect());
+    }
+
+    public function testItSkipsALinkToNowhere(): void
+    {
+        $this->filesystem->symlink($this->workingCopy.'/gone.php', $this->workingCopy.'/broken.php');
+
+        self::assertSame([realpath($this->workingCopy.'/src/code.php')], $this->collect());
+    }
+
+    /**
+     * Repositories do link within themselves, and that is ordinary - the link leaving the working copy is
+     * what makes one dangerous.
+     */
+    public function testItKeepsALinkWithinTheWorkingCopy(): void
+    {
+        $this->filesystem->symlink($this->workingCopy.'/src/code.php', $this->workingCopy.'/alias.php');
+
+        self::assertCount(2, $this->collect());
+    }
+
+    public function testItSkipsAFileTooLargeToMeasure(): void
+    {
+        $this->filesystem->dumpFile($this->workingCopy.'/generated.php', str_repeat('a', 5 * 1024 * 1024));
+
+        self::assertSame([realpath($this->workingCopy.'/src/code.php')], $this->collect());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collect(): array
+    {
+        return (new SourceFiles(new NullLogger()))->collect($this->workingCopy, 'owner/repository');
+    }
+}


### PR DESCRIPTION
Follow-up to the security review of the submission feature. Everything here comes from the same question: a submission is a stranger's input, and a lot of work runs on it afterwards.

## The one that mattered

git stores a symlink as faithfully as it stores source code, and `Finder->files()` matches one. A submitted repository containing `evil.php -> /dev/zero` therefore reached phploc, which reads what it is handed with `file_get_contents()` — the worker ran until the OOM killer took it, then messenger retried and it happened again. One submission, repeatable.

Verified end to end before the fix: the symlink survives `clone` + `checkout --force`, Finder matches it (`realpath=/dev/zero`), and the process dies. Pointed at `/etc/passwd` instead, the file was read and its lines counted into the public chart.

`SourceFiles` now owns the rule "which files may be measured": inside the working copy, a regular file, not larger than `MAX_FILE_SIZE`. Links **within** a repository are ordinary and still measured. `tests/ComplexityReport/SourceFilesTest.php` covers each case — three of the six fail against the previous behaviour.

## What else was unbounded

- **git had no timeout** (`setTimeout(null)`), so a remote that accepts a connection and then stalls held a worker forever. Every call now has one, generous enough that a large clone is unaffected.
- **No size check before cloning**, although github.com already tells us the size — it was read for the empty check and thrown away. Repositories above `MAX_SIZE` are refused now, and `RepositoryData` carries `size`.
- **No cap on work in flight**: `MAX_PENDING` repositories may wait for a worker, after which submissions are refused until the queue drains. This is the control that does not care how many IPs someone has.
- **404s were not cached**, so asking for repositories that never existed spent API quota per request. Without a `GITHUB_TOKEN` that is 60 requests an hour, and once it is gone *every* submission fails. Misses are now remembered for five minutes.

## The session leak

`submit` checked CSRF first and answered a bad token with a flash — and a flash starts a session. Unauthenticated, before the rate limiter, one session file per request, as many as someone cares to send. Reading the report starts no session, so this was the only path that did.

The limiter is now spent first, and both refusals a script runs into answer with a plain `429`/`400` instead of a flash. Everything a visitor runs into — unknown repository, fork, too little PHP — is still a flash on the start page. Confirmed: bad token → `400`, no `Set-Cookie`; sixth attempt → `429` with `Retry-After`, no `Set-Cookie`; a browser without javascript still passes CSRF on the same-origin check and gets its flash.

## Smaller ones

- `owner/..` was a valid identifier, and the api url built from it resolved to `https://api.github.com/repos/` rather than a repository. `.` and `..` are rejected, segments and inputs have a length.
- The api cache key joined path parts with `_`, which a repository may be named with: `/repos/a/b/languages` and `/repos/a/b_languages` shared one entry, so one request could be answered with the other's response. The separator is now one a name cannot contain.
- `git clone`/`ls-remote` pass `--` before the url and a tag is checked out as `refs/tags/<name>` — the argument guard was previously a version regex in another class.
- The search box ignores inputs too long to name a repository instead of running a `LIKE` for them.

## Not addressed

No global (cross-IP) rate limiter — `MAX_PENDING` covers the same ground more directly and drains by itself. `/search` still has no rate limit; it only reads the database.

`bin/check` passes: cs-fixer, phpstan level 8, 65 tests, yaml/twig/container lint, schema validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rebased onto Turbo Drive (#15)

Reconciled with the 303 change: the flash path still redirects with `HTTP_SEE_OTHER`, which is what turbo needs to read the next page with a GET. The two `refuse()` answers are deliberately *not* redirects — turbo renders a 4xx response body in place, so a refused request says what happened without a session being written for it.
