### PR TITLE
Read the label of the submit box before reaching the box

### DIFF
--- a/assets/styles/_screens.scss
+++ b/assets/styles/_screens.scss
@@ -6,14 +6,14 @@
 }
 
 // --- Start ------------------------------------------------------------------------------------
-// The input spans the band, with the label and the hint reading underneath it rather than beside it.
+// The input spans the band, announced by the label above it and explained by the hint underneath.
 .submit-band {
-    &__intro {
-        margin-top: var(--space-3);
+    &__label {
+        margin-bottom: var(--space-3);
     }
 
     &__hint {
-        margin-top: var(--space-2);
+        margin-top: var(--space-3);
         font-size: var(--text-sm);
         color: var(--text-muted);
     }

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -159,6 +159,11 @@
         <div class="band">
             <div class="wrap submit-band">
                 {#
+                 # The label announces the box before it is reached, the hint keeps reading under it:
+                 # what may be typed in only matters once the box is there.
+                 #}
+                <div class="eyebrow submit-band__label">Find or add a repository</div>
+                {#
                  # One box for both jobs. Picking a suggestion opens that repository, and anything the
                  # report does not carry yet is posted to `submit`, which queues it and opens its page.
                  # Without javascript the form still posts whatever was typed, which is what it did
@@ -187,17 +192,10 @@
                         <div class="alert alert--{{ label }}">{{ message }}</div>
                     {% endfor %}
                 {% endfor %}
-                {#
-                 # The box comes first and the words under it: the input is what the band is for, the
-                 # label and the hint only say what may be typed into it.
-                 #}
-                <div class="submit-band__intro">
-                    <div class="eyebrow">Find or add a repository</div>
-                    <p class="submit-band__hint">
-                        Everything the report carries, plus every public repository on GitHub that is mostly
-                        written in PHP - a composer.json is not needed.
-                    </p>
-                </div>
+                <p class="submit-band__hint">
+                    Everything the report carries, plus every public repository on GitHub that is mostly
+                    written in PHP - a composer.json is not needed.
+                </p>
             </div>
         </div>
 


### PR DESCRIPTION
The submit band said "Find or add a repository" *underneath* its input, so the box was met before it was announced. The label now sits above the input; the hint stays below it, since what may be typed in only matters once the box has been seen.

`submit-band__intro` is gone — the eyebrow carries `submit-band__label` (margin below) and the hint keeps its own margin above.

Checked: `lint:twig` passes, `prettier --check assets/` passes, and the stylesheet compiles. `yarn build` fails in this checkout for an unrelated reason — the shared `node_modules` predates `@hotwired/turbo` and needs a `yarn install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)