### PR TITLE
Name the git log channel with #[Target] instead of the parameter

### DIFF
--- a/src/ComplexityReport/Git.php
+++ b/src/ComplexityReport/Git.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\ComplexityReport;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\Process\Process;
 
 final readonly class Git
 {
     public function __construct(
+        #[Target('git')]
         private LoggerInterface $gitLogger,
     ) {
     }


### PR DESCRIPTION
The pipeline logs a deprecation on every container build:

> Since symfony/dependency-injection 8.1: Relying solely on the name of parameter `$gitLogger` of `__construct()` to match a named autowiring alias is deprecated; use the `#[Target]` attribute.

`AutowirePass` now warns whenever an argument resolves to a named alias purely through its parameter name and carries no `#[Target]`. `Git` is the only place in the app that does this — it takes the `git` monolog channel as `$gitLogger`.

MonologBundle registers the channel as `registerAliasForArgument($loggerId, LoggerInterface::class, 'git.logger', 'git')`, so the explicit target name is `git`. `#[Target('git')]` spells out what the parameter name was matching implicitly.

Verified by booting the prod kernel with a handler capturing `E_USER_DEPRECATED` around container compilation: the deprecation reproduces on `main` and is gone with the attribute, and it was the only one of its kind in the container. The compiled container still injects `monolog.logger.git`, so the `git` channel is unchanged.

`php-cs-fixer`, `phpstan`, `phpunit` (75 tests) and `lint:container` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)