### PR TITLE
Consume the schedule as the default one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ bin/console doctrine:migrations:diff              # after changing an entity
 
 # async
 bin/console messenger:consume async -vv           # the analysis queue
-bin/console messenger:consume scheduler_nightly   # the nightly release scan and star refresh
+bin/console messenger:consume scheduler_default   # the nightly release scan and star refresh
 bin/console messenger:stats                       # what is still queued
 bin/console debug:scheduler                       # next run of the recurring messages
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Two workers are needed - one for the queue, one for the schedule:
 
 ```bash
 symfony console messenger:consume async -vv
-symfony console messenger:consume scheduler_nightly -vv
+symfony console messenger:consume scheduler_default -vv
 ```
 
 The `async` transport may be consumed by several workers. Checking out a tag rewrites a working copy, so
@@ -138,7 +138,7 @@ stopasgroup=true
 killasgroup=true
 
 [program:oss_complexity_report_scheduler]
-command=php /var/www/oss-complexity-report/current/bin/console messenger:consume scheduler_nightly --time-limit=3600 --env=prod
+command=php /var/www/oss-complexity-report/current/bin/console messenger:consume scheduler_default --time-limit=3600 --env=prod
 process_name=%(program_name)s_%(process_num)02d
 numprocs=1
 user=deployer

--- a/src/Schedule.php
+++ b/src/Schedule.php
@@ -19,8 +19,11 @@ use Symfony\Contracts\Cache\CacheInterface;
  *
  * Both tasks are handed over to the `async` transport instead of being handled by the worker that
  * consumes the schedule - they walk every submitted repository and would block the next trigger.
+ *
+ * It is the only schedule of the application, so it stays the unnamed default one and the worker that
+ * triggers it consumes `scheduler_default`.
  */
-#[AsSchedule('nightly')]
+#[AsSchedule]
 final readonly class Schedule implements ScheduleProviderInterface
 {
     public function __construct(


### PR DESCRIPTION
The application has a single schedule, but `#[AsSchedule('nightly')]` named it — so the worker triggering it had to consume `scheduler_nightly`, a name nothing else in the setup carries. Production got it wrong (`scheduler_default`), so the scheduler worker has been crash-looping and the nightly release scan and star refresh never ran.

Dropping the name makes the transport `scheduler_default`, which is what a scheduler worker consumes by default.

- `src/Schedule.php` — `#[AsSchedule]` instead of `#[AsSchedule('nightly')]`, plus a line in the docblock saying why
- `README.md` / `CLAUDE.md` — the two `messenger:consume` invocations, including the supervisor snippet

The lock and the prose keep saying *nightly*: the run still happens at 02:00 and 03:00, only the transport name changes. `debug:scheduler` now lists the schedule as `default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)