### PR TITLE
Tighten the wordmark and the hero column against it

### DIFF
--- a/assets/styles/_base.scss
+++ b/assets/styles/_base.scss
@@ -176,11 +176,13 @@ canvas {
     background: var(--hero-bg);
     color: var(--hero-muted);
 
+    // stretched, not centred: the figure on the right is meant to stand as tall as the intro next
+    // to it, which it does by growing its own figure block rather than by being given a height.
     &__inner {
         display: flex;
         flex-wrap: wrap;
         gap: var(--space-7);
-        align-items: center;
+        align-items: stretch;
         justify-content: space-between;
     }
 
@@ -190,13 +192,15 @@ canvas {
 
     &__subline {
         max-width: 52ch;
-        margin-top: var(--space-5);
+        margin-top: var(--space-4);
         font-size: var(--text-lg);
         color: var(--hero-muted);
     }
 
+    // the mark has no height of its own to stretch, so it stays centred against the intro
     &__mark {
         flex: 0 0 auto;
+        align-self: center;
         width: clamp(104px, 16vw, 168px);
         height: auto;
     }
@@ -214,7 +218,9 @@ canvas {
 // be read in. The trend tones of the design system are ink on white and would sink into the brand
 // ground, so the number borrows the lightened bars of the mark instead.
 .hero-trend {
+    display: flex;
     flex: 0 0 auto;
+    flex-direction: column;
     width: clamp(260px, 26vw, 320px);
     padding: var(--space-5);
     background: rgba(255, 255, 255, 0.06);
@@ -230,7 +236,10 @@ canvas {
         color: var(--hero-faint);
     }
 
+    // the one visible figure takes whatever height the intro gives the card, so the time frames
+    // stay on its bottom edge without being pinned there
     &__figure {
+        flex: 1 1 auto;
         margin-top: var(--space-4);
 
         &[hidden] {
@@ -310,10 +319,12 @@ canvas {
     }
 }
 
-// The wordmark: a tracked-out mono kicker over the semibold product name. There is no logo file in
-// the repository - this lockup is the brand.
+// The wordmark: the semibold product name with a tracked-out mono kicker under it. There is no logo
+// file in the repository - this lockup is the brand. The two lines are set as tight as their leading
+// allows and ordered by the markup, which is why the hero can put the kicker on top instead.
 .logo {
     display: block;
+    line-height: var(--leading-lockup);
     color: inherit;
 
     &:hover {
@@ -322,7 +333,6 @@ canvas {
 
     &__kicker {
         display: block;
-        margin-bottom: 2px;
         font-family: var(--font-mono);
         font-size: var(--logo-kicker);
         font-weight: var(--weight-medium);
@@ -341,7 +351,7 @@ canvas {
     }
 
     &--hero &__kicker {
-        margin-bottom: var(--space-4);
+        margin-bottom: var(--space-2);
         font-size: var(--text-eyebrow);
     }
 

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -335,8 +335,8 @@
     &--hero {
         grid-template-columns: repeat(3, minmax(0, 1fr));
         max-width: 34rem;
-        margin-top: var(--space-7);
-        padding-bottom: 0;
+        margin-top: var(--space-5);
+        padding: var(--space-4) 0 0;
         border-top-color: var(--hero-line);
     }
 
@@ -353,10 +353,6 @@
     // Two columns is as far as the labels go before they collide - the hero row wraps with them.
     .stats {
         grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .stats--hero {
-        margin-top: var(--space-6);
     }
 }
 

--- a/assets/styles/_tokens.scss
+++ b/assets/styles/_tokens.scss
@@ -93,6 +93,8 @@
 
     --leading-body: 1.6;
     --leading-heading: 1.15;
+    // the two lines of the wordmark, set closer than any running text
+    --leading-lockup: 1.2;
     --tracking-heading: -0.02em;
     --tracking-tight: -0.01em;
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -27,8 +27,8 @@
                 <a class="site-header__brand" href="{{ path('start') }}">
                     {{ include('mark.html.twig', {size: 30}) }}
                     <span class="logo">
-                        <span class="logo__kicker">Open Source PHP Software</span>
                         <span class="logo__title">Complexity Report</span>
+                        <span class="logo__kicker">Open Source PHP Software</span>
                     </span>
                 </a>
                 <div class="site-header__right">


### PR DESCRIPTION
Fine tuning of the header lockup and the left half of the hero.

- **Header** - "Complexity Report" now sits above "Open Source PHP Software", and the two lines are set on a lockup leading (`--leading-lockup: 1.2`) instead of the body line height, so they read as one mark. The order comes from the markup, which is why the hero can keep the kicker on top.
- **Hero, left** - the kicker sits `--space-2` under the headline instead of `--space-4`, the subline moved up one step, and the figures follow at `--space-5` + a `--space-4` rule padding instead of `--space-7` + `--space-5`.
- **Hero, both halves** - the row stretches instead of centring and the trend card grows its visible figure, so it stands exactly as tall as the intro next to it (measured: both 257px at 1440px width) with the time frames on its bottom edge. The mark on the empty-state hero stays centred.

Checked with `yarn build`, `yarn check-style`, `bin/console lint:twig` and by rendering the start, narrow start and organization pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)