### PR TITLE
Raise the size a submitted repository may have to 10 GB

### DIFF
--- a/src/ComplexityReport/RepositorySubmitter.php
+++ b/src/ComplexityReport/RepositorySubmitter.php
@@ -30,10 +30,10 @@ final class RepositorySubmitter
      * Largest repository that is still worth cloning, in kilobytes - the unit github.com reports.
      *
      * Analysing means cloning the full history into a shared directory, and the submitter picks what
-     * lands there. Two gigabytes is far above what the source of a PHP project weighs and still bounds
+     * lands there. Ten gigabytes is far above what the source of a PHP project weighs and still bounds
      * what a single submission can cost the disk.
      */
-    private const int MAX_SIZE = 2 * 1024 * 1024;
+    private const int MAX_SIZE = 10 * 1024 * 1024;
 
     /**
      * How many repositories may wait for their first analysis at once.


### PR DESCRIPTION
`RepositorySubmitter::MAX_SIZE` goes from 2 GB to 10 GB (the constant is in kilobytes, the unit github.com reports, so `2 * 1024 * 1024` → `10 * 1024 * 1024`).

The cap bounds what a single submission may cost the disk before it is queued; raising it lets larger histories through while keeping that bound.

Note: `SubmissionFailed::oversizedRepository()` renders the limit in MB, so a rejection now reads "the limit is 10240 MB" — same formatting choice as before, just a bigger number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)