### PR TITLE
Link the tool the hero names

### DIFF
--- a/assets/styles/_base.scss
+++ b/assets/styles/_base.scss
@@ -195,6 +195,18 @@ canvas {
         margin-top: var(--space-4);
         font-size: var(--text-lg);
         color: var(--hero-muted);
+
+        // the brand coloured link of the site would sink into the brand ground, so what names the
+        // tool is the sentence itself, underlined, and brightens to the hero text on hover
+        a {
+            color: inherit;
+            text-decoration: underline;
+            text-underline-offset: 2px;
+
+            &:hover {
+                color: var(--hero-fg);
+            }
+        }
     }
 
     // the mark has no height of its own to stretch, so it stays centred against the intro

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -86,7 +86,8 @@
                     </div>
                     <p class="hero__subline">
                         How the cyclomatic complexity of PHP open source software evolved over time - one line
-                        per release, measured with phploc.
+                        per release, measured with
+                        <a href="https://github.com/sebastianbergmann/phploc" target="_blank" rel="noreferrer">phploc</a>.
                     </p>
                     <dl class="stats stats--hero">
                         <div>


### PR DESCRIPTION
The hero subline already says the report is measured with phploc — now the word says where that is: https://github.com/sebastianbergmann/phploc.

The site's link colour is the brand tone, which would sink into the brand ground of the hero, so the link is the sentence itself, underlined, and brightens to the hero text on hover.

Checked: `lint:twig` passes, `yarn check-style` passes, `yarn build` compiles the new rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)