### PR TITLE
Get the readme (and the repo) ready to be read publicly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,7 @@ bin/console messenger:stats                       # what is still queued
 bin/console debug:scheduler                       # next run of the recurring messages
 
 # frontend — Vite, wired into Twig by symfony/reprise
-yarn dev-server     # vite dev server with HMR, reprise points Twig at it
-yarn dev            # one-off development build
+yarn dev            # vite dev server with HMR, reprise points Twig at it
 yarn build          # production build (deploy.php sets ASSET_BASE for the sub path)
 yarn check-style    # prettier over assets/
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2026 Christopher Hertel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ starred ones.
 Requirements
 ------------
 
-* PHP 8.4
+* PHP 8.4 or newer
 * Node 26 (see .nvmrc) & Yarn
-* A database (e.g. PostgreSQL)
+* PostgreSQL - the migrations are written for it, `docker-compose.yml` starts a 15 on port 8432, which is
+  what `DATABASE_URL` in `.env` points at
+* git, since analysing a repository shells out to it
+* The [Symfony CLI][symfony-cli] - every command below is written as `symfony console`, which runs
+  `bin/console` with the environment of the local web server
 
 Setup
 -----
@@ -25,14 +29,44 @@ composer install
 yarn install
 yarn build
 docker-compose up -d
+symfony console doctrine:migrations:migrate
 symfony serve -d
 ```
+
+That is an empty report - it fills up by submitting repositories, either with the form on the start page
+or on the command line (see below). The fixtures submit a handful to start with.
+
+[symfony-cli]: https://symfony.com/download
 
 Assets are bundled by Vite and wired into Twig by [symfony/reprise][reprise].
 Run `yarn build` for a one-off build, or `yarn dev` to start the Vite dev
 server with hot module replacement - reprise picks it up automatically.
 
 [reprise]: https://github.com/symfony/reprise
+
+Checks
+------
+
+`bin/check` runs everything a pull request runs, plus prettier and `yarn audit`:
+
+```bash
+bin/check
+```
+
+Individually, if only one of them is interesting:
+
+```bash
+symfony php vendor/bin/phpunit                    # add --filter testName tests/Some/FileTest.php for one
+symfony php vendor/bin/php-cs-fixer fix           # --dry-run to only report
+symfony php vendor/bin/phpstan analyse            # level 8
+symfony console lint:yaml config --parse-tags
+symfony console lint:twig templates
+symfony console lint:container
+```
+
+The tests cover the domain logic that is pure - parsing what people paste, mapping the GitHub API,
+deciding which releases count, rolling the report up into the trend. Everything that needs a booted
+kernel is not covered yet.
 
 Background Processing
 ---------------------
@@ -152,3 +186,8 @@ quarter of an hour and IP, since each one spends github.com API quota and ends i
 
 Set `GITHUB_TOKEN` in `.env.local` to raise the github.com API rate limit from 60 to 5.000 requests per
 hour. The token only reads public data, so it does not need any scope.
+
+License
+-------
+
+MIT, see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@ Open Source Software Complexity Report
 
 Measures how the cyclomatic complexity of PHP open source software evolved over time.
 
+**[christopher-hertel.de/oss-complexity-report][report]**
+
 Every repository on github.com that is mostly written in PHP can be submitted - a `composer.json` is not
 needed, so `wordpress/wordpress` works just as well as `symfony/console`. Submitted repositories are
 grouped by the GitHub account that owns them, and the start page and the overview chart focus on the most
 starred ones.
+
+[report]: https://christopher-hertel.de/oss-complexity-report/
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ symfony console messenger:consume async -vv
 symfony console messenger:consume scheduler_default -vv
 ```
 
-The `async` transport may be consumed by several workers. Checking out a tag rewrites a working copy, so
-an analysis holds a lock per repository and a second worker on the same one waits instead of measuring
+The `async` transport may be consumed by several workers, `scheduler_default` must stay at exactly one -
+otherwise the nightly run happens more than once. Checking out a tag rewrites a working copy, so an
+analysis holds a lock per repository and a second worker on the same one waits instead of measuring
 whatever the first one just checked out. The lock is a `flock` by default (see `LOCK_DSN`), which only
 works if all workers run on the same machine - switch it to `postgresql+advisory://` if they ever do not.
 
@@ -105,61 +106,12 @@ symfony console app:data:fix -vv
 
 `messenger:stats` shows what is left to do.
 
-Deploying schema changes
-------------------------
+Schema changes
+--------------
 
-The schema is managed by doctrine/migrations and `deploy.php` runs them right before the symlink switches.
-
-The production database predates the migration history, so its baseline would try to create tables that are
-already there. It recognizes them and records itself as executed instead - nothing to do by hand.
-
-After the deploy that turns libraries into repositories, run `app:repositories:refresh` once to fill in the
-stars and descriptions the migration leaves empty.
-
-Workers in production
----------------------
-
-The workers run under supervisor and are restarted onto the new release by `deploy.php`, which expects the
-programs to be named `oss_complexity_report_consumer` and `oss_complexity_report_scheduler`:
-
-```ini
-[program:oss_complexity_report_consumer]
-command=php /var/www/oss-complexity-report/current/bin/console messenger:consume async --time-limit=3600 --env=prod
-process_name=%(program_name)s_%(process_num)02d
-numprocs=2
-user=deployer
-autostart=true
-autorestart=true
-startsecs=0
-; analysing a big repository takes minutes - let it finish instead of killing it mid-checkout
-stopwaitsecs=900
-; the worker shells out to git, so signals have to reach the whole process group
-stopasgroup=true
-killasgroup=true
-
-[program:oss_complexity_report_scheduler]
-command=php /var/www/oss-complexity-report/current/bin/console messenger:consume scheduler_default --time-limit=3600 --env=prod
-process_name=%(program_name)s_%(process_num)02d
-numprocs=1
-user=deployer
-autostart=true
-autorestart=true
-startsecs=0
-stopwaitsecs=30
-stopasgroup=true
-killasgroup=true
-```
-
-The scheduler must stay at `numprocs=1`; the consumer may be scaled up. `deploy.php` restarts both with
-`sudo supervisorctl`, so the deploy user needs to be allowed to run it.
-
-The same goes for `sudo systemctl reload php8.4-fpm`: php-fpm reaches the application through the `current`
-symlink, so opcache serves the release that was compiled under that path until the pool is reloaded - a
-deploy without it moves the symlink and changes nothing about what visitors get. Both grants together:
-
-```
-deployer ALL=(root) NOPASSWD: /usr/bin/supervisorctl, /usr/bin/systemctl reload php8.4-fpm
-```
+The schema is managed by doctrine/migrations, never by `doctrine:schema:update` - run
+`doctrine:migrations:diff` after changing an entity and `doctrine:migrations:migrate` to apply what came
+out of it. A deploy runs the pending migrations before it switches to the new release.
 
 Error Reporting
 ---------------
@@ -167,8 +119,8 @@ Error Reporting
 Errors are reported to [Sentry][sentry] - uncaught exceptions of the web app, of the console commands and
 of everything the workers run. It is configured by `SENTRY_DSN`, which is empty everywhere but production:
 without a DSN the SDK collects nothing and sends nothing, so nothing has to be switched off for local
-development. Set it in `.env.local` to try it out, and in the `.env.local` on the server - deployer shares
-that file between releases - to turn it on in production.
+development. Set it in `.env.local` to try it out, and in the environment of the deployment to turn it on
+in production.
 
 Two things are deliberately not reported: 404 and 405, which on a public site are what bots produce rather
 than what is broken, and messages that are going to be retried. A repository another worker is holding

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "stoffel/oss-complexiy-report",
+    "name": "chr-hertel/oss-complexity-report",
     "description": "Complexity Analysis of open source software projects",
     "type": "project",
     "license": "MIT",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "273cc5ed283c8892c5b15076b5dedf62",
+    "content-hash": "f411de8f622bd9789034a2e75552e826",
     "packages": [
         {
             "name": "doctrine/collections",

--- a/config/packages/prod/webpack_encore.yaml
+++ b/config/packages/prod/webpack_encore.yaml
@@ -1,4 +1,0 @@
-#webpack_encore:
-    # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
-    # Available in version 1.2
-    #cache: true


### PR DESCRIPTION
Started as "drop the server specifics from the readme", then became a pass over the whole repository with a public reader in mind.

## Server specifics out

The readme carried a full supervisor config with absolute paths, the deploy user, the sudoers grants and the php-fpm reload - that describes one machine, not the application.

- **Workers in production** removed entirely. Its one app-level fact - the schedule must be consumed by exactly one worker, `async` may be scaled - moved into *Background Processing*, next to the consume commands.
- **Deploying schema changes** → **Schema changes**: migrations, `diff` after an entity change, and that a deploy applies them. The baseline note about the production database and the one-off refresh after the libraries → repositories deploy are gone.
- The Sentry section no longer says where the production `.env.local` lives.

## Licence

`composer.json` and `package.json` have both claimed MIT for years, but no `LICENSE` file existed - so github reported no licence and nobody could rely on the claim. Added the MIT text (2020-2026) and a *License* section.

## The readme now gets a fresh clone running

`composer install && yarn build && docker-compose up -d && symfony serve` leaves you with a database container and no schema, so the first request fails. `doctrine:migrations:migrate` is part of setup now, and the requirements name what the readme was silently assuming: the Symfony CLI every command is written with, git, and PostgreSQL rather than "a database" (the migrations use `GENERATED BY DEFAULT AS IDENTITY`).

Added a **Checks** section - `bin/check`, the individual commands, and what the tests do and do not cover.

## Leftovers

- `config/packages/prod/webpack_encore.yaml`: a fully commented out recipe file for a bundle that is not installed.
- Package name was `stoffel/oss-complexiy-report` - wrong account, "complexity" misspelled. Only the lock file's content hash follows; no dependency changes.
- `CLAUDE.md` documented a `yarn dev-server` script that does not exist.

## Verified

From this worktree, which is a clean checkout without `vendor/`: `composer install` (ok), `phpunit` 99 tests green, `php-cs-fixer --dry-run` clean, `phpstan` no errors, `lint:yaml` / `lint:twig` / `lint:container` / `doctrine:schema:validate --skip-sync` all pass, `composer validate --strict` valid, `composer audit` reports no advisories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Live report

The readme links [the running report](https://christopher-hertel.de/oss-complexity-report/) under the intro - a reader arriving from github could not see the thing without building it first.
