### PR TITLE
Name the first nav item after the screen, not its list

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -18,7 +18,9 @@
     <body>
         {#
          # The top band of every page: the mark next to the wordmark on the left, a mono nav on the
-         # right. Two screens, so two items - what the report carries, and the chart it is read in.
+         # right. Two screens, so two items - the report at a glance, and the chart it is read in. The
+         # first one is not called after what it lists: the chart lists repositories too, and only the
+         # start screen carries the trend, the search and the queue alongside them.
          #}
         {% set route = app.request.attributes.get('_route') %}
         <header class="site-header">
@@ -33,7 +35,7 @@
                 <div class="site-header__right">
                     <nav class="site-header__nav">
                         <a class="site-header__link {{ route == 'start' ? 'is-active' }}"
-                           href="{{ path('start') }}">Repositories</a>
+                           href="{{ path('start') }}">Overview</a>
                         <a class="site-header__link {{ route == 'chart' ? 'is-active' }}"
                            href="{{ path('chart') }}">Chart</a>
                         <a class="site-header__link" target="_blank" rel="noreferrer"


### PR DESCRIPTION
`Repositories` did not separate the first nav item from `Chart`: the chart draws repositories too, so only one of the two items said so. And the start screen is more than that list — the trend hero, the search box and the queue sit next to it, while "Repositories" is already the label of a *stat* in the same hero.

`Overview` names the screen it opens instead of one thing on it.

```
Complexity Report        Overview   Chart   GitHub
Open Source PHP Software  ^^^^^^^^
```

The comment above the nav is updated to say why the item is not named after what it lists.

`bin/console lint:twig templates` passes; nothing in `assets/` or `tests/` referenced the old label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)