### PR TITLE
Make the chart readable after a zoom and clickable release by release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,11 @@ preselected repositories from a `data-repositories` attribute rendered by `templ
 lazily fetches additional ones from the `repository` JSON route when picked in the select2 box - what is
 picked is written back into the query string, so a chart someone put together is a link. The release
 analysis below the chart is one tab per line, built from the same graphs: every repository in the chart can
-be read release by release, and a tab carries the colour of its series.
+be read release by release, and a tab carries the colour of its series - and since a point in the chart
+*is* a release, clicking one opens it there: the line it belongs to becomes the tab being read and the
+point the release, scrolled to only when the section is off screen. The chart zooms and pans
+(chartjs-plugin-zoom), which the address bar knows nothing about, so the way back is the `.chart-reset`
+button floating over it - rendered `hidden` and shown by the controller only while `isZoomedOrPanned()`.
 `trend_controller.js` switches the time frame of the hero figure, which is rendered for all four windows
 at once, so nothing is fetched when one is picked.
 `refresh_controller.js` reloads the page every 30s while the status above the chart says a repository is

--- a/assets/controllers/chart_controller.js
+++ b/assets/controllers/chart_controller.js
@@ -89,6 +89,7 @@ export default class extends Controller {
         'headline',
         'headlineLink',
         'canvas',
+        'resetZoom',
         'select',
         'release',
         'releaseTabs',
@@ -164,6 +165,12 @@ export default class extends Controller {
             options: {
                 maintainAspectRatio: false,
                 interaction: { mode: 'nearest', intersect: false },
+                // whatever the tooltip is pointing at is what a click reads below the chart, so the
+                // point that answers the click is the one the pointer already named
+                onClick: (event, elements) => this.pickPoint(elements),
+                onHover: (event, elements) => {
+                    this.canvasTarget.style.cursor = elements.length > 0 ? 'pointer' : 'default';
+                },
                 plugins: {
                     legend: {
                         position: 'bottom',
@@ -191,8 +198,13 @@ export default class extends Controller {
                         },
                     },
                     zoom: {
-                        pan: { enabled: true },
-                        zoom: { wheel: { enabled: true }, pinch: { enabled: true }, mode: 'xy' },
+                        pan: { enabled: true, onPanComplete: () => this.reflectZoom() },
+                        zoom: {
+                            wheel: { enabled: true },
+                            pinch: { enabled: true },
+                            mode: 'xy',
+                            onZoomComplete: () => this.reflectZoom(),
+                        },
                     },
                 },
                 scales: {
@@ -212,6 +224,47 @@ export default class extends Controller {
                 },
             },
         });
+    }
+
+    /**
+     * Zooming has no address bar to go back in, so the way out of it is a button - and one that is
+     * only there while there is something to undo, since an untouched chart has nothing to reset.
+     */
+    reflectZoom() {
+        if (this.hasResetZoomTarget) {
+            this.resetZoomTarget.hidden = !this.chart?.isZoomedOrPanned();
+        }
+    }
+
+    resetZoom() {
+        this.chart?.resetZoom();
+        this.reflectZoom();
+    }
+
+    /**
+     * A point in the chart is a release, and the release analysis below is where a release is read -
+     * so clicking one opens it there: its repository becomes the tab being read, and the point itself
+     * the release, whichever line it belongs to.
+     */
+    pickPoint(elements) {
+        const point = elements[0];
+
+        if (!point || !this.hasReleaseTarget) {
+            return;
+        }
+
+        this.showRepository(this.chart.data.datasets[point.datasetIndex].label, point.index);
+        this.revealRelease();
+    }
+
+    /**
+     * The chart fills the screen it is clicked in, so the answer to a click is usually below the fold -
+     * scrolled to only then, since nothing should move under someone who can already see it.
+     */
+    revealRelease() {
+        if (this.releaseTarget.getBoundingClientRect().top > window.innerHeight - 120) {
+            this.releaseTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
     }
 
     initSelectBox() {
@@ -261,6 +314,7 @@ export default class extends Controller {
             backgroundColor: SERIES_COLORS[index % SERIES_COLORS.length],
         }));
         this.chart.update();
+        this.reflectZoom();
 
         this.renderHeadline(slugs);
         this.renderTabs(graphs);
@@ -365,7 +419,11 @@ export default class extends Controller {
         this.showRepository(event.currentTarget.dataset.name);
     }
 
-    showRepository(name) {
+    /**
+     * Reading a repository starts at its newest release, unless the reader said which one - clicking a
+     * point in the chart does.
+     */
+    showRepository(name, index = null) {
         const graph = this.series.find((entry) => entry.name === name);
 
         if (!graph) {
@@ -395,7 +453,7 @@ export default class extends Controller {
             this.releaseSelectTarget.prepend(option);
         });
 
-        this.showRelease(graph.tags.length - 1);
+        this.showRelease(null === index ? graph.tags.length - 1 : index);
     }
 
     selectRelease(event) {

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -578,6 +578,50 @@ a.chip:hover {
     height: 420px;
 }
 
+// The way out of a zoom, floating over the top right corner of the chart - only there while the chart
+// is zoomed or panned, so an untouched chart carries nothing.
+.chart-reset {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 5px var(--space-3);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: var(--weight-medium);
+    line-height: 1.4;
+    color: var(--text-muted);
+    background: var(--surface-card);
+    border: var(--border-width) solid var(--line);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-xs);
+    cursor: pointer;
+    transition:
+        color var(--transition),
+        border-color var(--transition);
+
+    &:hover {
+        color: var(--text-heading);
+        border-color: var(--line-strong);
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+    }
+
+    &[hidden] {
+        display: none;
+    }
+
+    i {
+        font-size: 10px;
+        color: var(--text-faint);
+    }
+}
+
 // --- Trend ------------------------------------------------------------------------------------
 // A signed complexity change, coloured by direction: green when complexity fell, clay red when it
 // rose, grey when it held.

--- a/templates/chart.html.twig
+++ b/templates/chart.html.twig
@@ -96,7 +96,10 @@
                 </div>
             {% elseif series is not empty %}
                 <div>
-                    <p class="chart-lead">Average cyclomatic complexity per analysed release.</p>
+                    <p class="chart-lead">
+                        Average cyclomatic complexity per analysed release. Scroll to zoom, drag to pan,
+                        and click a release to read it below.
+                    </p>
 
                     {#
                      # What the chart is drawn from stands above it: everything the report carries can be
@@ -121,6 +124,15 @@
                     <div class="panel chart-panel">
                         <div class="chart-canvas">
                             <canvas data-chart-target="canvas"></canvas>
+                            {#
+                             # Zooming leaves the chart somewhere the browser knows nothing about, so the
+                             # way back is a button - shown by the controller only while there is a zoom
+                             # or a pan to undo.
+                             #}
+                            <button type="button" class="chart-reset" data-chart-target="resetZoom"
+                                    data-action="chart#resetZoom" hidden>
+                                <i class="fas fa-arrows-to-dot"></i> Reset zoom
+                            </button>
                         </div>
                     </div>
 


### PR DESCRIPTION
Two improvements to the chart screen.

**Reset zoom.** The chart zooms and pans, but nothing undid it - a zoom is not in the address bar, so a
reload was the only way out. A `Reset zoom` button now floats over the top right corner of the chart. It is
rendered `hidden` and shown by the controller only while `isZoomedOrPanned()`, driven by the zoom plugin's
`onZoomComplete` / `onPanComplete`, so an untouched chart carries nothing.

**Clicking a release.** A point in the chart *is* a release, and the release analysis below is where a
release is read - so clicking a point opens it there: the line it belongs to becomes the tab being read and
the point itself the release, whichever series it was drawn in. `onClick` is answered with the same element
the tooltip is already naming (`interaction: nearest`), the cursor turns into a pointer over the chart, and
the section is scrolled to only when it is off screen. The lead above the chart says all of this in a line.

Verified in headless Chrome against the local dataset: clicking a `nikic/PHP-Parser` point while
`symfony/symfony` was the tab being read switched both the tab and the release; a wheel zoom revealed the
button and clicking it hid it again. `yarn build`, `yarn check-style` and `lint:twig` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)