### PR TITLE
Read the owner above the name on every card

### DIFF
--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -43,20 +43,20 @@
     {% endif %}
 {% endmacro %}
 
+{#
+ # Owner above name on every card, the way github.com reads them - `symfony/symfony` saying its name
+ # twice is what that repository is called, and dropping the line for it only left the head empty.
+ #}
 {% macro card(repository, ranking, rank) %}
-    {# `wordpress/wordpress` would read its own name twice, so the vendor line is dropped for those #}
-    {% set showVendor = repository.organization.login|lower != repository.shortName|lower %}
     <div class="repo-card">
         <div class="repo-card__body">
             <div class="repo-card__head">
                 <span class="repo-card__rank">{{ rank < 10 ? '0' }}{{ rank }}</span>
-                {% if showVendor %}
-                    <span class="repo-card__vendor">{{ repository.organization.login }}</span>
-                {% endif %}
+                <span class="repo-card__vendor">{{ repository.organization.login }}</span>
             </div>
             <h3 class="repo-card__title">
                 <a href="{{ path('chart', {'repositories': repository.name}) }}">
-                    {{ showVendor ? repository.shortName : repository.name }}
+                    {{ repository.shortName }}
                 </a>
             </h3>
             <p class="repo-card__text">{{ repository.description }}</p>


### PR DESCRIPTION
On the ranking page the owner line is missing for some cards - `symfony/symfony`, `composer/composer`, `WordPress/WordPress` - while every other card carries it.

The macro dropped the line whenever the owner repeated the repository name, so it would not be read twice, but the title then fell back to the full slug. The name was read twice regardless, only in one line, and the card head was left holding nothing but the rank.

Every card now reads owner above name, the way github.com writes them.

| before | after |
| --- | --- |
| `03` / `symfony/symfony` | `03  SYMFONY` / `symfony` |

`bin/console lint:twig templates` and `vendor/bin/phpunit` (113 tests) pass; the change is template-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)