### PR TITLE
Rank the latest increases instead of the fastest change

### DIFF
--- a/src/ComplexityReport/Ranking.php
+++ b/src/ComplexityReport/Ranking.php
@@ -15,7 +15,7 @@ enum Ranking: string
     case Stars = 'stars';
     case Complexity = 'complexity';
     case Size = 'size';
-    case Evolution = 'evolution';
+    case Growth = 'growth';
 
     /**
      * @return list<self>
@@ -31,7 +31,7 @@ enum Ranking: string
             self::Stars => 'Most starred',
             self::Complexity => 'Highest complexity',
             self::Size => 'Largest',
-            self::Evolution => 'Fastest changing',
+            self::Growth => 'Latest Increases',
         };
     }
 
@@ -44,7 +44,7 @@ enum Ranking: string
             self::Stars => null,
             self::Complexity => 'Ø',
             self::Size => 'LOC',
-            self::Evolution => '%',
+            self::Growth => '%',
         };
     }
 
@@ -54,7 +54,7 @@ enum Ranking: string
             self::Stars => 'Most starred repositories',
             self::Complexity => 'Highest average complexity',
             self::Size => 'Largest codebases',
-            self::Evolution => 'Biggest change over time',
+            self::Growth => 'Biggest increase in the last 12 months',
         };
     }
 
@@ -64,7 +64,7 @@ enum Ranking: string
             self::Stars => 'The order the report itself is built around - stars decide what the chart opens with.',
             self::Complexity => 'Average cyclomatic complexity of the latest analysed release, across all methods and functions.',
             self::Size => 'Lines of code in the latest analysed release, as phploc counts them.',
-            self::Evolution => 'Change in average complexity between the first and the latest analysed release - green means the codebase got simpler, red means it got hairier.',
+            self::Growth => 'Repositories whose average complexity grew the most within the last 12 months, measured against the release they stood at back then - the window the figure above uses as well.',
         };
     }
 
@@ -75,9 +75,26 @@ enum Ranking: string
      */
     public function sort(array $repositories, int $limit): array
     {
-        usort($repositories, $this->comparator());
+        $ranked = array_values(array_filter($repositories, $this->filter()));
 
-        return array_slice($repositories, 0, $limit);
+        usort($ranked, $this->comparator());
+
+        return array_slice($ranked, 0, $limit);
+    }
+
+    /**
+     * What a ranking has no room for. Only the increases leave anything out: a repository that got
+     * simpler within the window did not increase, and neither did one that has not released in it -
+     * both are 0.0 or less, which is nothing to rank.
+     *
+     * @return callable(Repository): bool
+     */
+    private function filter(): callable
+    {
+        return match ($this) {
+            self::Growth => static fn (Repository $repository) => $repository->getRecentEvolution() > 0.0,
+            default => static fn (Repository $repository) => true,
+        };
     }
 
     /**
@@ -91,7 +108,7 @@ enum Ranking: string
             self::Stars => static fn (Repository $left, Repository $right) => $right->getStars() <=> $left->getStars(),
             self::Complexity => static fn (Repository $left, Repository $right) => [$right->getComplexity(), $right->getStars()] <=> [$left->getComplexity(), $left->getStars()],
             self::Size => static fn (Repository $left, Repository $right) => [$right->getLinesOfCode(), $right->getStars()] <=> [$left->getLinesOfCode(), $left->getStars()],
-            self::Evolution => static fn (Repository $left, Repository $right) => [abs($right->getEvolution()), $right->getStars()] <=> [abs($left->getEvolution()), $left->getStars()],
+            self::Growth => static fn (Repository $left, Repository $right) => [$right->getRecentEvolution(), $right->getStars()] <=> [$left->getRecentEvolution(), $left->getStars()],
         };
     }
 }

--- a/src/Entity/Repository.php
+++ b/src/Entity/Repository.php
@@ -19,6 +19,11 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: RepositoryRepository::class)]
 class Repository
 {
+    /**
+     * How far back {@see self::getRecentEvolution()} looks - the twelve months the report calls recent.
+     */
+    private const string RECENT = '-12 months';
+
     #[ORM\Id, ORM\Column(type: 'integer'), ORM\GeneratedValue]
     private int $id;
 
@@ -184,14 +189,37 @@ class Repository
      */
     public function getEvolution(): float
     {
-        $first = $this->getFirstTag()?->getAverageComplexity() ?? 0.0;
-        $last = $this->getComplexity();
+        return self::change($this->getFirstTag()?->getAverageComplexity() ?? 0.0, $this->getComplexity());
+    }
 
-        if (0.0 === $first) {
-            return 0.0;
+    /**
+     * The same figure for the last twelve months - what the "Latest Increases" ranking is ordered by,
+     * over the window the hero rolls the whole report up into.
+     */
+    public function getRecentEvolution(): float
+    {
+        return $this->getEvolutionSince(new \DateTimeImmutable(self::RECENT));
+    }
+
+    /**
+     * How the average complexity changed since a point in time, in percent.
+     *
+     * The repository is compared against the release it stood at back then, which is the rule the hero
+     * trend follows as well. Two cases have nothing to say and are 0.0 rather than a made up number: a
+     * repository that was not measured yet when the window opened, and one that has not released since -
+     * there the baseline is the latest release, so nothing changed within the window.
+     */
+    public function getEvolutionSince(\DateTimeImmutable $since): float
+    {
+        $baseline = null;
+
+        foreach ($this->tags as $tag) {
+            if ($tag->getCreated() <= $since && (null === $baseline || $tag->getCreated() > $baseline->getCreated())) {
+                $baseline = $tag;
+            }
         }
 
-        return round((($last - $first) / $first) * 100, 1);
+        return self::change($baseline?->getAverageComplexity() ?? 0.0, $this->getComplexity());
     }
 
     public function getLocalPath(): string
@@ -225,5 +253,18 @@ class Repository
     public function asGraph(): GraphData
     {
         return new GraphData($this);
+    }
+
+    /**
+     * Change between two average complexities, in percent - a release without a single class has no
+     * average to compare against, so it is no change rather than a division by zero.
+     */
+    private static function change(float $from, float $to): float
+    {
+        if (0.0 === $from) {
+            return 0.0;
+        }
+
+        return round((($to - $from) / $from) * 100, 1);
     }
 }

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -32,6 +32,13 @@
         </span>
     {% endset %}
 
+    {% set growth %}
+        <span class="metric metric--{{ repository.recentEvolution|trend_tone }}"
+              title="Change in average complexity within the last 12 months - measured against the release it stood at back then">
+            <span class="metric__label">12M</span>{{ repository.recentEvolution|signed_percent }}
+        </span>
+    {% endset %}
+
     {% if ranking == 'stars' %}
         {{ stars }}{{ complexity }}{{ evolution }}
     {% elseif ranking == 'complexity' %}
@@ -39,7 +46,7 @@
     {% elseif ranking == 'size' %}
         {{ linesOfCode }}{{ releases }}{{ stars }}
     {% else %}
-        {{ evolution }}{{ complexity }}{{ stars }}
+        {{ growth }}{{ complexity }}{{ stars }}
     {% endif %}
 {% endmacro %}
 
@@ -233,11 +240,19 @@
                              aria-labelledby="tab-{{ entry.ranking.value }}"
                              data-rankings-target="panel" {{ not loop.first ? 'hidden' }}>
                             <p class="ranking__caption">{{ entry.ranking.caption }}</p>
-                            <div class="repo-grid">
-                                {% for repository in entry.repositories %}
-                                    {{ _self.card(repository, entry.ranking.value, loop.index) }}
-                                {% endfor %}
-                            </div>
+                            {#
+                             # A ranking can come out empty although the report has data - nothing
+                             # increased within the last twelve months is a result, not a broken page.
+                             #}
+                            {% if entry.repositories is empty %}
+                                <p class="empty-state">Nothing the report carries got more complex within the last 12 months.</p>
+                            {% else %}
+                                <div class="repo-grid">
+                                    {% for repository in entry.repositories %}
+                                        {{ _self.card(repository, entry.ranking.value, loop.index) }}
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
                         </div>
                     {% endfor %}
                 {% else %}

--- a/tests/ComplexityReport/RankingTest.php
+++ b/tests/ComplexityReport/RankingTest.php
@@ -33,8 +33,8 @@ final class RankingTest extends TestCase
         yield 'stars' => [Ranking::Stars, ['a/popular', 'a/huge', 'a/hairy', 'a/moving']];
         yield 'complexity' => [Ranking::Complexity, ['a/hairy', 'a/huge', 'a/popular', 'a/moving']];
         yield 'size' => [Ranking::Size, ['a/huge', 'a/popular', 'a/hairy', 'a/moving']];
-        // the biggest change in either direction comes first, so a drop beats a smaller rise
-        yield 'evolution' => [Ranking::Evolution, ['a/moving', 'a/hairy', 'a/popular', 'a/huge']];
+        // only what grew within the window, the biggest increase first - a drop is not an increase
+        yield 'growth' => [Ranking::Growth, ['a/hairy', 'a/popular']];
     }
 
     public function testItCutsTheListToTheLimit(): void
@@ -74,6 +74,9 @@ final class RankingTest extends TestCase
     }
 
     /**
+     * The first release is old enough to be the baseline of every window, the latest one is recent - so
+     * what these repositories did to their complexity, they did within the last twelve months.
+     *
      * @param array{int, float} $first
      * @param array{int, float} $latest
      */
@@ -88,11 +91,10 @@ final class RankingTest extends TestCase
             $stars,
         );
 
-        $created = new \DateTimeImmutable('2020-01-01');
+        $created = ['1.0' => new \DateTimeImmutable('-3 years'), '2.0' => new \DateTimeImmutable('-1 month')];
 
         foreach (['1.0' => $first, '2.0' => $latest] as $tag => [$linesOfCode, $complexity]) {
-            $repository->addTag(new GitTag($tag), new Analysis($linesOfCode, $complexity, $created));
-            $created = $created->modify('+1 year');
+            $repository->addTag(new GitTag($tag), new Analysis($linesOfCode, $complexity, $created[$tag]));
         }
 
         return $repository;

--- a/tests/Entity/RepositoryTest.php
+++ b/tests/Entity/RepositoryTest.php
@@ -33,6 +33,7 @@ final class RepositoryTest extends TestCase
         self::assertSame(0, $repository->getLinesOfCode());
         self::assertSame(0.0, $repository->getComplexity());
         self::assertSame(0.0, $repository->getEvolution());
+        self::assertSame(0.0, $repository->getRecentEvolution());
     }
 
     /**
@@ -56,6 +57,60 @@ final class RepositoryTest extends TestCase
         yield 'a single release did not evolve yet' => [['1.0' => [100, 2.0]], 0.0];
         // a release without a single class has no average to compare against
         yield 'no complexity to compare' => [['1.0' => [100, 0.0], '2.0' => [100, 2.0]], 0.0];
+    }
+
+    /**
+     * @dataProvider windows
+     *
+     * @param list<array{string, float, string}> $releases
+     */
+    public function testItMeasuresTheEvolutionSinceAPointInTime(array $releases, float $expected): void
+    {
+        $repository = self::repositoryReleasedAt($releases);
+
+        self::assertSame($expected, $repository->getEvolutionSince(new \DateTimeImmutable('-12 months')));
+    }
+
+    /**
+     * @return iterable<string, array{list<array{string, float, string}>, float}>
+     */
+    public static function windows(): iterable
+    {
+        // the release the repository stood at when the window opened is what it is compared against,
+        // not its first one - 2.5 a year ago against 3.0 today, although it started out at 2.0
+        yield 'the release it stood at back then' => [
+            [['1.0', 2.0, '-3 years'], ['2.0', 2.5, '-18 months'], ['3.0', 3.0, '-6 months']],
+            20.0,
+        ];
+        yield 'nothing released within the window' => [
+            [['1.0', 2.0, '-3 years'], ['2.0', 4.0, '-2 years']],
+            0.0,
+        ];
+        yield 'not measured yet when the window opened' => [
+            [['1.0', 2.0, '-6 months'], ['2.0', 3.0, '-1 month']],
+            0.0,
+        ];
+    }
+
+    public function testTheRecentEvolutionCoversTheLastTwelveMonths(): void
+    {
+        $repository = self::repositoryReleasedAt([['1.0', 2.0, '-13 months'], ['2.0', 2.5, '-1 month']]);
+
+        self::assertSame(25.0, $repository->getRecentEvolution());
+    }
+
+    /**
+     * @param list<array{string, float, string}> $releases
+     */
+    private static function repositoryReleasedAt(array $releases): Repository
+    {
+        $repository = self::repositoryWith([]);
+
+        foreach ($releases as [$name, $complexity, $created]) {
+            $repository->addTag(new GitTag($name), new Analysis(100, $complexity, new \DateTimeImmutable($created)));
+        }
+
+        return $repository;
     }
 
     /**


### PR DESCRIPTION
The "Fastest changing" ranking sorted by the biggest move in either direction between a repository's first and latest release, so a library that got much simpler over a decade led a ranking about complexity. It is now **Latest Increases**: the repositories whose average complexity grew the most within the last 12 months.

- `Repository::getEvolutionSince()` measures a repository against the release it stood at when the window opened - the same rule `TrendCalculator` follows for the hero figure, so the ranking and the 12M trend above it agree on what "the last twelve months" means. `getRecentEvolution()` is the one-line clock edge on top of it.
- `Ranking::Growth` sorts by that figure, descending, and filters out everything that did not grow: a repository that got simpler did not increase, and one that has not released within the window compares against its own latest release, so it reads 0%.
- The cards in that ranking now show the 12M figure instead of the all-time one; the other rankings keep the "since <year>" metric they had.
- A ranking that comes out empty says so instead of rendering an empty grid - nothing increasing in twelve months is a result, not a broken page.

Checked with `vendor/bin/phpunit` (117 tests), `phpstan`, `php-cs-fixer --dry-run` and `lint:twig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)