### PR TITLE
Say what the release head knows about a repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,12 +208,13 @@ submitted: no releases yet means no lines but a status telling the visitor it is
 right now - the one state the browser cannot rename, since nothing can be picked in it.
 
 Routes are distinguished by `priority`, since `{organization}` and the slug of a repository both match
-whatever is left: `chart`/`search`/`submit` (3) > `repository` (2, `owner/repository`, returns the releases
-as JSON - the slug is the whole route, so the select box can request it relative to the page it is on) >
-`organization` (1). The last one is the page GitHub accounts used to have, kept as a permanent redirect
-into the chart - `?repository=<id>` included, since that is how the links that were handed out address a
-repository. `Repository::asGraph()` returns a `GraphData` value object that JSON-serializes into what the
-chart expects.
+whatever is left: `chart`/`search`/`submit` (3) > `repository` (2, `owner/repository`, returns one line of
+the chart as JSON - the slug is the whole route, so the select box can request it relative to the page it
+is on) > `organization` (1). The last one is the page GitHub accounts used to have, kept as a permanent
+redirect into the chart - `?repository=<id>` included, since that is how the links that were handed out
+address a repository. `Repository::asGraph()` returns a `GraphData` value object that JSON-serializes into
+what the chart expects: the releases it draws plus the github.com url and the stars of the repository they
+belong to, so a line picked later carries the same facts as one the page was rendered with.
 
 **Frontend** — Vite + symfony/reprise + StimulusBundle. `assets/controllers/chart_controller.js` reads the
 preselected repositories from a `data-repositories` attribute rendered by `templates/chart.html.twig`, and
@@ -222,7 +223,11 @@ picked is written back into the query string, so a chart someone put together is
 analysis below the chart is one tab per line, built from the same graphs: every repository in the chart can
 be read release by release, and a tab carries the colour of its series - and since a point in the chart
 *is* a release, clicking one opens it there: the line it belongs to becomes the tab being read and the
-point the release, scrolled to only when the section is off screen. The chart zooms and pans
+point the release, scrolled to only when the section is off screen. Its head says what a release is read
+against: the repository it belongs to, linking to github.com and carrying its stars and its first measured
+release, and the day the release was tagged - which is the only date the report has, since when a release
+was measured is whenever it was submitted or a nightly scan found it and says nothing about the code.
+The chart zooms and pans
 (chartjs-plugin-zoom), which the address bar knows nothing about, so the way back is the `.chart-reset`
 button floating over it - rendered `hidden` and shown by the controller only while `isZoomedOrPanned()`.
 `trend_controller.js` switches the time frame of the hero figure, which is rendered for all four windows

--- a/assets/controllers/chart_controller.js
+++ b/assets/controllers/chart_controller.js
@@ -40,6 +40,21 @@ function element(tag, className, text) {
 const count = (value) => value.toLocaleString('en-US');
 const decimal = (value, digits) =>
     value.toLocaleString('en-US', { minimumFractionDigits: digits, maximumFractionDigits: digits });
+const day = (value) => moment(value, 'YYYY-MM-DD').format('LL');
+const dot = () => element('span', 'release-head__dot', '·');
+
+// the star count of the rankings, shortened the way the `stars` twig filter shortens it
+function stars(total) {
+    const node = element('span', 'metric metric--star');
+
+    node.title = `${count(total)} stars on GitHub`;
+    node.append(
+        element('i', 'fas fa-star'),
+        element('span', null, total < 1000 ? String(total) : `${(total / 1000).toFixed(1).replace(/\.0$/, '')}k`),
+    );
+
+    return node;
+}
 
 // complexity going down is an improvement, going up is a regression
 const tone = (value) => (Math.abs(value) < 0.005 ? 'flat' : value < 0 ? 'good' : 'bad');
@@ -365,7 +380,8 @@ export default class extends Controller {
             // the slug is the whole route, so a relative request keeps working under a deployed sub path
             const response = await fetch(slug, { headers: { Accept: 'application/json' } });
 
-            this.graphs.set(slug, { name: slug, tags: await response.json() });
+            // the route answers with the line itself, the same shape the page was rendered with
+            this.graphs.set(slug, await response.json());
         }
 
         return this.graphs.get(slug);
@@ -467,26 +483,44 @@ export default class extends Controller {
         const first = tags[0];
 
         this.releaseSelectTarget.value = String(index);
-        this.releaseRepositoryTarget.textContent = this.release.name;
         this.releaseNameTarget.textContent = tag.name;
 
-        this.releaseMetaTarget.replaceChildren(
-            element('span', null, `Measured with phploc on ${moment(tag.date, 'YYYY-MM-DD').format('LL')}`),
+        // where the release is read on github.com - the name of the repository is its address there
+        this.releaseRepositoryTarget.href = this.release.url;
+        this.releaseRepositoryTarget.title = this.release.url.replace('https://', '');
+        this.releaseRepositoryTarget.replaceChildren(
+            element('span', null, this.release.name),
+            element('i', 'fas fa-arrow-up-right-from-square'),
         );
+
+        /*
+         * The date a release carries is the day it was tagged, not the day the report measured it - the
+         * measurement happened whenever the repository was submitted or a nightly scan picked the release
+         * up, which is not what anyone reading a release is after.
+         */
+        this.releaseMetaTarget.replaceChildren(element('span', null, `Released on ${day(tag.date)}`));
 
         if (previous) {
             this.releaseMetaTarget.append(
-                element('span', 'release-head__dot', '·'),
+                dot(),
                 element('span', null, 'Ø complexity'),
                 trend(Math.round((tag.y - previous.y) * 100) / 100, 2, `vs ${previous.name}`),
             );
         }
 
+        // what the repository behind the line is, next to the release being read from it
+        this.releaseMetaTarget.append(
+            dot(),
+            stars(this.release.stars),
+            dot(),
+            element('span', null, `First release ${day(first.date)}`),
+        );
+
         const complexities = tags.map((entry) => entry.y);
 
         const groups = [
             group('Release', [
-                row('Released', moment(tag.date, 'YYYY-MM-DD').format('LL')),
+                row('Released', day(tag.date)),
                 row('Lines of code (LOC)', count(tag.loc)),
                 row('Ø cyclomatic complexity', decimal(tag.y, 2)),
             ]),
@@ -502,11 +536,11 @@ export default class extends Controller {
                       row('Ø complexity', trend(Math.round((tag.y - first.y) * 100) / 100, 2)),
                   ])
                 : null,
+            // the first release is in the head, above every group - it says what the repository is
             group(`All ${tags.length} releases`, [
                 row('Analysed releases', count(tags.length)),
                 row('Lowest Ø complexity', decimal(Math.min(...complexities), 2)),
                 row('Highest Ø complexity', decimal(Math.max(...complexities), 2)),
-                row('First release', moment(first.date, 'YYYY-MM-DD').format('LL')),
             ]),
         ];
 

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -723,9 +723,23 @@ a.chip:hover {
         font-size: var(--text-h3);
     }
 
+    // the repository is a link to github.com, so it carries the same arrow the chart headline does
     &__name {
         font-family: var(--font-mono);
         font-weight: var(--weight-medium);
+        color: inherit;
+        text-decoration: none;
+
+        .fas {
+            margin-left: var(--space-2);
+            font-size: 13px;
+            color: var(--text-faint);
+        }
+
+        // only the name is underlined on hover, the arrow behind it is not part of it
+        &:hover span {
+            text-decoration: underline;
+        }
     }
 
     &__meta {

--- a/src/ComplexityReport/GraphData.php
+++ b/src/ComplexityReport/GraphData.php
@@ -44,13 +44,18 @@ final class GraphData implements \JsonSerializable
     }
 
     /**
-     * @return array{name: string, tags: list<array{name: string, x: string, date: string, y: float, loc: int}>, labels: list<string>}
+     * A line of the chart: what it is called, where it comes from and the releases it is drawn from.
+     * `url` and `stars` are what the release analysis says about the repository behind the line.
+     *
+     * @return array{name: string, url: string, stars: int, tags: list<array{name: string, x: string, date: string, y: float, loc: int}>, labels: list<string>}
      */
     public function jsonSerialize(): array
     {
         return [
             // the select box addresses a repository by its slug, which is the name it is drawn under
             'name' => $this->repository->getName(),
+            'url' => $this->repository->getUrl(),
+            'stars' => $this->repository->getStars(),
             'tags' => $this->getTagData(),
             'labels' => $this->getLabels(),
         ];

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -175,16 +175,17 @@ final class ReportController extends AbstractController
     }
 
     /**
-     * The releases behind one line of the chart. A repository is addressed the way github.com addresses
-     * it, and that slug is the whole route - so the select box can request it relative to the page it is
-     * on, which keeps working under a deployed sub path.
+     * One line of the chart: the repository and the releases behind it, in the shape the page is
+     * rendered with, so a line picked later reads the same as one the page opened on. A repository is
+     * addressed the way github.com addresses it, and that slug is the whole route - so the select box
+     * can request it relative to the page it is on, which keeps working under a deployed sub path.
      */
     #[Route('{name}', name: 'repository', requirements: ['name' => '[^/]+/[^/]+'], methods: 'GET', priority: 2)]
     public function repository(string $name, RepositoryRepository $repositories): JsonResponse
     {
         $repository = $repositories->findBySlug($name) ?? throw $this->createNotFoundException();
 
-        return new JsonResponse($repository->asGraph()->getTagData());
+        return new JsonResponse($repository->asGraph());
     }
 
     /**

--- a/templates/chart.html.twig
+++ b/templates/chart.html.twig
@@ -97,7 +97,8 @@
             {% elseif series is not empty %}
                 <div>
                     <p class="chart-lead">
-                        Average cyclomatic complexity per analysed release. Scroll to zoom, drag to pan,
+                        Average cyclomatic complexity per analysed release, measured with phploc. Scroll
+                        to zoom, drag to pan,
                         and click a release to read it below.
                     </p>
 
@@ -148,7 +149,9 @@
                         <div class="release-head">
                             <div>
                                 <h2>
-                                    <span class="release-head__name" data-chart-target="releaseRepository"></span>
+                                    {# the repository being read is where it is read on github.com #}
+                                    <a class="release-head__name" target="_blank" rel="noreferrer"
+                                       data-chart-target="releaseRepository"></a>
                                     <span class="badge" data-chart-target="releaseName"></span>
                                 </h2>
                                 <div class="release-head__meta" data-chart-target="releaseMeta"></div>


### PR DESCRIPTION
The head of the release analysis claimed a release was *measured* on the day it was tagged - it was not: a release is measured whenever its repository was submitted or a nightly scan picked it up, which is a date the report does not keep and which says nothing about the code. It reads `Released on <date>` now, and the phploc attribution moved into the lead above the chart, where it is true of every line in it.

Next to that date the head now answers what reading a release asks about the repository behind it:

- the repository name links to github.com (`https://github.com/<owner>/<name>`, the url the entity carries),
- its stars, as the same shortened figure the rankings show (`17.5k`, full count in the title),
- its first measured release, moved up from the `All N releases` group - which said the same thing three panels lower.

For that, the `repository` route answers with the whole line instead of only its tags: `GraphData` serializes `url` and `stars` alongside `name`/`tags`, so a repository picked in the select box later carries the same facts as one the page was rendered with.

Checked with `phpstan`, `php-cs-fixer --dry-run`, `phpunit` (113 tests), `lint:twig`, `prettier --check` and `yarn build`, and the section was rendered against the local dataset to see the head come out as `nikic/PHP-Parser ↗ v5.8.0 / Released on July 4, 2026 · Ø complexity ↑+0.01 vs v5.7.0 · ★ 17.5k · First release January 5, 2012`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)