### PR TITLE
List an owner only where it groups something

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,9 @@ an unknown repository, a fork, too little PHP - stays a flash on the start page,
 ends on the page of its repository, whether it was just queued or has been in the report for years.
 
 **Web** (`src/Controller/ReportController`) — two screens: `start` renders the trend in the hero, the
-submit form, the rankings, a line of GitHub owners and what is still queued, and `chart` is everything
+submit form, the rankings, a line of GitHub owners (only those grouping more than one measured
+repository - a single one is the repository the rankings already link to) and what is still queued, and
+`chart` is everything
 else. There is **one** chart page, not one per organization: `?repositories=symfony/console,nikic/iter`
 says which repositories it draws, in that order, up to `CHART_LIMIT` (the chart has eight colours), and
 anything the report carries can be added to them. Without a selection it opens on the most starred.

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -57,7 +57,7 @@ final class ReportController extends AbstractController
         return $this->render('start.html.twig', [
             'rankings' => $rankings,
             'hasData' => [] !== $analysed,
-            'organizations' => $organizationRepository->findWithData(),
+            'organizations' => $organizationRepository->findWithSeveralRepositories(),
             'pending' => $repositoryRepository->findPending(),
             'statistics' => $statisticsLoader->load(),
             'trends' => $trendLoader->load(),

--- a/src/Repository/OrganizationRepository.php
+++ b/src/Repository/OrganizationRepository.php
@@ -42,11 +42,13 @@ final class OrganizationRepository extends ServiceEntityRepository
     }
 
     /**
-     * Only the organizations that have something to chart - everything else links to an empty report.
+     * The organizations that group something: they need more than one repository to chart, and every one
+     * of those needs releases - an owner of a single repository is that repository, which the rankings
+     * already link to, and an owner without measured releases links to an empty report.
      *
      * @return list<Organization>
      */
-    public function findWithData(): array
+    public function findWithSeveralRepositories(): array
     {
         $queryBuilder = $this->createQueryBuilder('o');
 
@@ -58,6 +60,7 @@ final class OrganizationRepository extends ServiceEntityRepository
                 sprintf('SELECT t.id FROM %s t WHERE t.repository = r', Tag::class)
             ))
             ->groupBy('o.id')
+            ->having('COUNT(r.id) > 1')
             ->orderBy('stars', 'DESC')
             ->addOrderBy('o.login', 'ASC')
             ->getQuery()

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -246,7 +246,9 @@
 
                 {#
                  # The GitHub accounts behind the repositories are a lens on the same list, not a place of
-                 # their own: every one of them opens the chart with what was submitted for it.
+                 # their own: every one of them opens the chart with what was submitted for it. Which is
+                 # why only accounts with more than one repository are listed - a single one is a link to
+                 # that repository under another name.
                  #}
                 {% if organizations is not empty %}
                     <p class="owner-line">


### PR DESCRIPTION
The owner line on the start page is a lens on the repositories, not a place of its own — so an account with a single repository is that repository under another name, and the rankings right above already link to it.

`OrganizationRepository::findWithData()` becomes `findWithSeveralRepositories()`: same query, plus `HAVING COUNT(r.id) > 1` over the repositories that have measured releases.

Checked against the local dataset: the line goes from every analysed owner to `symfony` and `nikic` (2 repositories each).

php-cs-fixer, phpstan (level 8), phpunit (113 tests) and `lint:twig` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)