### PR TITLE
Give the chart the box the start page has

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,7 @@ chart expects.
 
 **Frontend** — Vite + symfony/reprise + StimulusBundle. `assets/controllers/chart_controller.js` reads the
 preselected repositories from a `data-repositories` attribute rendered by `templates/chart.html.twig`, and
-lazily fetches additional ones from the `repository` JSON route when picked in the select2 box - what is
+lazily fetches additional ones from the `repository` JSON route when picked in the box above it - what is
 picked is written back into the query string, so a chart someone put together is a link. The release
 analysis below the chart is one tab per line, built from the same graphs: every repository in the chart can
 be read release by release, and a tab carries the colour of its series - and since a point in the chart
@@ -233,9 +233,20 @@ data is there, and a backgrounded tab skips its turn. Page transitions are Turbo
 imported in `assets/app.js`; swup and its per-page controller are gone): it takes over every link and form
 of the site at once, the fade is the browser's view transition enabled by the `view-transition` meta tag,
 and `submit` answers with **303** because turbo follows a form's redirect itself. What Turbo caches for the
-back button is the page as it looks when it is left, so `chart_controller.js` tears its select2 box down on
-`turbo:before-cache` as well as on disconnect. `vite.config.js` takes the public path from `ASSET_BASE`
-(set by the build task in `deploy.php`) rather than the build mode, so local production builds keep working.
+back button is the page as it looks when it is left, which is why every box renders itself by replacing
+what is there: a page that comes back open comes back the same, not doubled. `vite.config.js` takes the
+public path from `ASSET_BASE` (set by the build task in `deploy.php`) rather than the build mode, so local
+production builds keep working.
+
+Both boxes people type in are the **same** control: `assets/combobox.js` is the menu under a field - the
+rows, opening and closing it, and the keyboard that walks it, with what a row says and what picking one
+means left to the box that built it. `search_controller.js` is the one on the start page, which asks the
+server what an input means; `repository_picker_controller.js` is the one above the chart, which has more
+than one answer - a chip per line, coloured by its position, which is why a pick moves its option to the
+end of the `<select>` behind it. That select is the state, not a widget: the picker writes to it and
+dispatches its `change`, so the chart is redrawn by one event however a repository got in or out. Only the
+keyboard highlights a row (`.is-active`) - hovering is the pointer's own business, and picking happens on
+`mousedown`, before the blur that closes the menu can race it.
 
 **Error reporting** (`config/packages/sentry.yaml`) — sentry/sentry-symfony, registered by hand since
 `allow-contrib` is false and its recipe therefore never ran. `SENTRY_DSN` is empty in the committed `.env`

--- a/assets/combobox.js
+++ b/assets/combobox.js
@@ -1,0 +1,128 @@
+/*
+ * The listbox that hangs under a field: the search box on the start page and the repository box above
+ * the chart are the same control, so the part that is the same lives here - the rows, the menu it
+ * opens, and the keyboard that walks it.
+ *
+ * What a row says and what picking one means stays with the box that built it: this only knows that a
+ * row was chosen and by which of the two ways.
+ */
+export function element(tag, className, text) {
+    const node = document.createElement(tag);
+
+    if (className) {
+        node.className = className;
+    }
+
+    if (undefined !== text) {
+        node.textContent = text;
+    }
+
+    return node;
+}
+
+export class Combobox {
+    /**
+     * @param input the field the menu belongs to
+     * @param menu the list it is drawn in, identified so a row can be pointed at
+     * @param pick called with the position of the row that was chosen
+     */
+    constructor(input, menu, pick) {
+        this.input = input;
+        this.menu = menu;
+        this.pick = pick;
+        this.length = 0;
+        this.active = -1;
+    }
+
+    /**
+     * Shows what the box found. Rows are `<li>`s it built itself; nothing found is a line saying so,
+     * because a menu that closes on a typo looks like a box that stopped working.
+     */
+    show(rows, empty) {
+        this.length = rows.length;
+        this.menu.replaceChildren();
+
+        if (0 === rows.length) {
+            this.menu.append(element('li', 'combobox__empty', empty));
+        }
+
+        rows.forEach((row, index) => {
+            row.id = `${this.menu.id}-${index}`;
+            row.setAttribute('role', 'option');
+            row.setAttribute('aria-selected', 'false');
+            // on mousedown the input has not lost focus yet, so picking never races the blur that closes
+            row.addEventListener('mousedown', (event) => {
+                event.preventDefault();
+                this.pick(index);
+            });
+
+            this.menu.append(row);
+        });
+
+        // a new list is a list nothing is on yet, and what the field points at has to say so too
+        this.highlight(-1);
+        this.open();
+    }
+
+    open() {
+        this.menu.hidden = false;
+        this.input.setAttribute('aria-expanded', 'true');
+    }
+
+    close() {
+        this.menu.hidden = true;
+        this.active = -1;
+        this.input.setAttribute('aria-expanded', 'false');
+        this.input.removeAttribute('aria-activedescendant');
+    }
+
+    /**
+     * The keys the menu answers. Everything else is typing and belongs to the field, which is what the
+     * return value says.
+     */
+    navigate(event) {
+        if ('Escape' === event.key) {
+            this.close();
+
+            return true;
+        }
+
+        if ('Enter' === event.key && this.active >= 0) {
+            event.preventDefault();
+            this.pick(this.active);
+
+            return true;
+        }
+
+        if (('ArrowDown' !== event.key && 'ArrowUp' !== event.key) || 0 === this.length) {
+            return false;
+        }
+
+        event.preventDefault();
+
+        // the input itself is one of the stops, so arrowing past either end lands back in it
+        const stops = this.length + 1;
+        const step = 'ArrowDown' === event.key ? 1 : -1;
+
+        this.highlight(((this.active + 1 + step + stops) % stops) - 1);
+
+        return true;
+    }
+
+    /** The row the keyboard is on - only the keyboard: hovering is the pointer's own business. */
+    highlight(index) {
+        this.active = index;
+
+        [...this.menu.children].forEach((row, position) => {
+            row.classList.toggle('is-active', position === index);
+            row.setAttribute('aria-selected', position === index ? 'true' : 'false');
+        });
+
+        if (index >= 0) {
+            this.input.setAttribute('aria-activedescendant', this.menu.children[index].id);
+            this.menu.children[index].scrollIntoView({ block: 'nearest' });
+        } else {
+            this.input.removeAttribute('aria-activedescendant');
+        }
+    }
+}

--- a/assets/controllers/chart_controller.js
+++ b/assets/controllers/chart_controller.js
@@ -3,17 +3,11 @@ import Chart from 'chart.js/auto';
 import 'chartjs-adapter-moment';
 import zoomPlugin from 'chartjs-plugin-zoom';
 import moment from 'moment';
-import select2 from 'select2';
-import $ from 'jquery';
-
-// select2's CommonJS build exports a factory rather than registering itself on
-// jQuery. Webpack's interop happened to call it; Vite's does not, so importing
-// it for its side effect alone leaves $.fn.select2 undefined.
-select2(window, $);
+import { element } from '../combobox.js';
 
 // The eight series colours of the design system, assigned by position. The swatch in front of every
-// chip in the select box is coloured by the same rule, see _components.scss - which only holds as long
-// as the order of the datasets is the order of the chips, hence moveToEnd() and the full re-render.
+// chip in the picker is coloured by the same rule, see _components.scss - which only holds as long as
+// the order of the datasets is the order of the chips, which is why a pick goes to the end of both.
 const SERIES_COLORS = ['#2f3a49', '#c05b4d', '#b58a3c', '#4e8c7d', '#4a6fa5', '#7c6ba0', '#7a9a4e', '#a0a8b4'];
 const GRID = '#e3e7ec';
 const TICK = '#5a6675';
@@ -22,20 +16,6 @@ const MONO = 'IBM Plex Mono';
 const SANS = 'IBM Plex Sans';
 
 const ARROWS = { good: '↓', bad: '↑', flat: '→' };
-
-function element(tag, className, text) {
-    const node = document.createElement(tag);
-
-    if (className) {
-        node.className = className;
-    }
-
-    if (undefined !== text) {
-        node.textContent = text;
-    }
-
-    return node;
-}
 
 const count = (value) => value.toLocaleString('en-US');
 const decimal = (value, digits) =>
@@ -121,39 +101,12 @@ export default class extends Controller {
         this.series = [];
         this.repository = null;
         this.initChart();
-        this.initSelectBox();
         this.render();
-
-        /*
-         * Turbo snapshots the page for its back button while the page is still on screen - before this
-         * controller disconnects, so the select box has to be torn down for the snapshot as well.
-         * Otherwise coming back would restore select2's rendered widget and then draw a second one
-         * next to it.
-         */
-        this.beforeCache = () => this.teardown();
-        document.addEventListener('turbo:before-cache', this.beforeCache);
     }
 
     disconnect() {
-        document.removeEventListener('turbo:before-cache', this.beforeCache);
-        this.teardown();
-    }
-
-    teardown() {
-        if (!this.hasSelectTarget) {
-            return;
-        }
-
         this.chart?.destroy();
         this.chart = null;
-
-        const $select = $(this.selectTarget);
-
-        $select.off();
-
-        if ($select.data('select2')) {
-            $select.select2('destroy');
-        }
     }
 
     initChart() {
@@ -267,29 +220,18 @@ export default class extends Controller {
         }
     }
 
-    initSelectBox() {
-        const $select = $(this.selectTarget);
-
-        $select.select2({ width: '100%', placeholder: 'Search analysed repositories' });
-        $select.on('select2:select', this.moveToEnd);
-        $select.on('select2:select select2:unselect', () => this.render(true));
-    }
-
     /**
-     * select2 leaves a picked option where it sits in the markup, so its chips would be in a different
-     * order than the chart series - and the colour of a chip is the colour of its line.
+     * The picker above the chart is a box of its own and says what it holds by changing the select it
+     * is a widget for - which is also what the chart was rendered with, so adding a line and opening
+     * the page on it are the same thing to everything below.
      */
-    moveToEnd(event) {
-        const $option = $(event.params.data.element);
-
-        $option.detach();
-        $(this).append($option);
-        $(this).trigger('change.select2');
+    repick() {
+        this.render(true);
     }
 
     async render(picked = false) {
         const run = ++this.renders;
-        const slugs = $(this.selectTarget).val() || [];
+        const slugs = this.hasSelectTarget ? [...this.selectTarget.selectedOptions].map((option) => option.value) : [];
 
         if (picked) {
             this.syncUrl(slugs);

--- a/assets/controllers/repository_picker_controller.js
+++ b/assets/controllers/repository_picker_controller.js
@@ -1,0 +1,155 @@
+import { Controller } from '@hotwired/stimulus';
+import { Combobox, element } from '../combobox.js';
+
+/*
+ * The box above the chart: which repositories it draws. It is the start page's combobox with more than
+ * one answer - a chip per line, in the order the chart draws them, and a menu of everything the report
+ * carries that is not in it yet.
+ *
+ * The select behind it is the state, not the widget: picking writes to it and dispatches its `change`,
+ * so the chart is redrawn by one event whether a chip was added, removed or arrived with the page.
+ */
+export default class extends Controller {
+    static targets = ['select', 'chips', 'input', 'menu'];
+    static values = { limit: Number };
+
+    connect() {
+        this.combobox = new Combobox(this.inputTarget, this.menuTarget, (index) => this.pick(index));
+        // turbo caches the page as it was left, so a box left open would come back open - a page
+        // starts on its chart, not halfway through picking one
+        this.combobox.close();
+        this.inputTarget.value = '';
+        this.renderChips();
+    }
+
+    disconnect() {
+        this.combobox.close();
+    }
+
+    /** The whole box is one field, so clicking next to the chips aims for the only thing to type in. */
+    focus() {
+        this.inputTarget.focus();
+    }
+
+    /**
+     * Everything the report carries that is not in the chart yet - the chips above are where a
+     * repository is taken out again, so the menu never repeats one.
+     */
+    query() {
+        const search = this.inputTarget.value.trim().toLowerCase();
+        const full = this.selected().length >= this.limitValue;
+
+        this.options = full
+            ? []
+            : [...this.selectTarget.options].filter(
+                  (option) => !option.selected && option.value.toLowerCase().includes(search),
+              );
+
+        this.combobox.show(
+            this.options.map((option) => {
+                const row = element('li', 'combobox__option');
+
+                row.append(element('span', 'combobox__name', option.value));
+
+                return row;
+            }),
+            this.nothing(full, '' !== search),
+        );
+    }
+
+    /**
+     * An empty menu is three different answers, and saying the wrong one reads like a box that stopped
+     * working: the chart is full, the report is in it already, or nothing goes by that name.
+     */
+    nothing(full, searching) {
+        if (full) {
+            return `The chart draws ${this.limitValue} lines at a time - remove one to add another.`;
+        }
+
+        return searching
+            ? 'Nothing in the report matches that.'
+            : 'Everything the report carries is already in this chart.';
+    }
+
+    navigate(event) {
+        if (this.combobox.navigate(event)) {
+            return;
+        }
+
+        // an empty field backspaces into the chips, the way a field full of them is emptied again
+        if ('Backspace' === event.key && '' === this.inputTarget.value) {
+            const chips = this.selected();
+
+            if (chips.length > 0) {
+                this.deselect(chips[chips.length - 1]);
+            }
+        }
+    }
+
+    close() {
+        this.combobox.close();
+    }
+
+    pick(index) {
+        const option = this.options[index];
+
+        if (!option) {
+            return;
+        }
+
+        option.selected = true;
+        option.setAttribute('selected', 'selected');
+        // the position of a chip is the colour of its line, so a pick goes to the end of both
+        this.selectTarget.append(option);
+        // one pick is rarely the only one, so the box stays open on what is left of the report
+        this.inputTarget.value = '';
+        this.commit();
+    }
+
+    remove(event) {
+        const option = [...this.selectTarget.options].find((entry) => entry.value === event.params.name);
+
+        if (option) {
+            this.deselect(option);
+        }
+    }
+
+    deselect(option) {
+        option.selected = false;
+        option.removeAttribute('selected');
+        this.commit();
+    }
+
+    commit() {
+        this.renderChips();
+
+        // the menu is what is not in the chart, so taking a repository out puts it back on
+        if (!this.menuTarget.hidden) {
+            this.query();
+        }
+
+        this.selectTarget.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    renderChips() {
+        this.chipsTarget.replaceChildren(
+            ...this.selected().map((option) => {
+                const chip = element('li', 'combobox__chip');
+                const remove = element('button', 'combobox__chip-remove', '×');
+
+                remove.type = 'button';
+                remove.dataset.action = 'repository-picker#remove';
+                remove.dataset.repositoryPickerNameParam = option.value;
+                remove.setAttribute('aria-label', `Remove ${option.value} from the chart`);
+
+                chip.append(element('span', 'combobox__swatch'), element('span', null, option.value), remove);
+
+                return chip;
+            }),
+        );
+    }
+
+    selected() {
+        return [...this.selectTarget.selectedOptions];
+    }
+}

--- a/assets/controllers/search_controller.js
+++ b/assets/controllers/search_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
+import { Combobox, element } from '../combobox.js';
 
 /*
  * The search box on the start page. It asks the server what an input means - a repository the report
@@ -10,20 +11,6 @@ import { Controller } from '@hotwired/stimulus';
  */
 const DEBOUNCE = 200;
 
-function element(tag, className, text) {
-    const node = document.createElement(tag);
-
-    if (className) {
-        node.className = className;
-    }
-
-    if (undefined !== text) {
-        node.textContent = text;
-    }
-
-    return node;
-}
-
 const stars = (value) => (value < 1000 ? String(value) : String((value / 1000).toFixed(1)).replace(/\.0$/, '') + 'k');
 
 export default class extends Controller {
@@ -32,13 +19,13 @@ export default class extends Controller {
 
     connect() {
         this.options = [];
-        this.active = -1;
+        this.combobox = new Combobox(this.inputTarget, this.menuTarget, (index) => this.pick(index));
         this.requests = 0;
     }
 
     disconnect() {
         clearTimeout(this.timer);
-        this.close();
+        this.combobox.close();
     }
 
     query() {
@@ -86,103 +73,43 @@ export default class extends Controller {
             ...result.repositories.map((repository) => ({ type: 'open', repository })),
             ...(result.submittable ? [{ type: 'submit', name: result.submittable.name }] : []),
         ];
-        this.active = -1;
-        this.menuTarget.replaceChildren();
 
-        if (0 === this.options.length) {
-            this.menuTarget.append(
-                element('li', 'combobox__empty', 'Nothing found - paste a vendor/repository to add it.'),
-            );
-            this.open();
+        this.combobox.show(
+            this.options.map((option) => this.row(option)),
+            'Nothing found - paste a vendor/repository to add it.',
+        );
+    }
 
-            return;
-        }
+    row(option) {
+        const node = element('li', 'combobox__option');
 
-        this.options.forEach((option, index) => {
-            const node = element('li', 'combobox__option');
+        if ('open' === option.type) {
+            const meta = element('span', 'combobox__meta');
 
-            node.id = `search-suggestion-${index}`;
-            node.setAttribute('role', 'option');
-            node.setAttribute('aria-selected', 'false');
-            // on mousedown the input has not lost focus yet, so picking never races the blur that closes
-            node.addEventListener('mousedown', (event) => {
-                event.preventDefault();
-                this.pick(index);
-            });
+            meta.append(element('i', 'fas fa-star'), element('span', null, stars(option.repository.stars)));
 
-            if ('open' === option.type) {
-                const meta = element('span', 'combobox__meta');
-
-                meta.append(element('i', 'fas fa-star'), element('span', null, stars(option.repository.stars)));
-
-                if (!option.repository.analysed) {
-                    meta.append(element('span', 'combobox__badge', 'queued'));
-                }
-
-                node.append(element('span', 'combobox__name', option.repository.name), meta);
-
-                if (option.repository.description) {
-                    node.append(element('span', 'combobox__description', option.repository.description));
-                }
-            } else {
-                node.classList.add('combobox__option--add');
-                node.append(
-                    element('span', 'combobox__name', option.name),
-                    element('span', 'combobox__meta', 'add to the report'),
-                );
+            if (!option.repository.analysed) {
+                meta.append(element('span', 'combobox__badge', 'queued'));
             }
 
-            this.menuTarget.append(node);
-        });
+            node.append(element('span', 'combobox__name', option.repository.name), meta);
 
-        this.open();
+            if (option.repository.description) {
+                node.append(element('span', 'combobox__description', option.repository.description));
+            }
+        } else {
+            node.classList.add('combobox__option--add');
+            node.append(
+                element('span', 'combobox__name', option.name),
+                element('span', 'combobox__meta', 'add to the report'),
+            );
+        }
+
+        return node;
     }
 
     navigate(event) {
-        if ('Escape' === event.key) {
-            this.close();
-
-            return;
-        }
-
-        if ('Enter' === event.key && this.active >= 0) {
-            event.preventDefault();
-            this.pick(this.active);
-
-            return;
-        }
-
-        if ('ArrowDown' !== event.key && 'ArrowUp' !== event.key) {
-            return;
-        }
-
-        if (0 === this.options.length) {
-            return;
-        }
-
-        event.preventDefault();
-
-        // the input itself is one of the stops, so arrowing past either end lands back in it
-        const stops = this.options.length + 1;
-        const step = 'ArrowDown' === event.key ? 1 : -1;
-
-        this.highlight(((this.active + 1 + step + stops) % stops) - 1);
-    }
-
-    highlight(index) {
-        this.active = index;
-
-        [...this.menuTarget.children].forEach((node, position) => {
-            node.classList.toggle('is-active', position === index);
-            node.setAttribute('aria-selected', position === index ? 'true' : 'false');
-        });
-
-        if (index >= 0) {
-            this.inputTarget.setAttribute('aria-activedescendant', `search-suggestion-${index}`);
-            this.menuTarget.children[index].scrollIntoView({ block: 'nearest' });
-        } else {
-            this.inputTarget.removeAttribute('aria-activedescendant');
-        }
+        this.combobox.navigate(event);
     }
 
     pick(index) {
@@ -204,15 +131,7 @@ export default class extends Controller {
         this.element.requestSubmit();
     }
 
-    open() {
-        this.menuTarget.hidden = false;
-        this.inputTarget.setAttribute('aria-expanded', 'true');
-    }
-
     close() {
-        this.menuTarget.hidden = true;
-        this.active = -1;
-        this.inputTarget.setAttribute('aria-expanded', 'false');
-        this.inputTarget.removeAttribute('aria-activedescendant');
+        this.combobox.close();
     }
 }

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -397,11 +397,105 @@ a.chip:hover {
 }
 
 // --- Combobox ---------------------------------------------------------------------------------
-// The search box on the start page: the design system's field over a menu of suggestions.
+// A field over a menu of suggestions: the search on the start page, and the repository box above the
+// chart - which is the same box with room for more than one answer, so the chips and the field they
+// sit in are the only part it adds.
 .combobox {
     position: relative;
     flex: 1 1 auto;
     min-width: 0;
+
+    // the chips and the input read as one field, so the border is around all of them
+    &__control {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+        align-items: center;
+        min-height: 42px;
+        padding: calc(var(--space-2) - 2px) var(--space-3);
+        background: var(--surface-input);
+        border: var(--border-width) solid var(--input-border-color);
+        border-radius: var(--radius);
+        cursor: text;
+        transition:
+            border-color var(--transition),
+            box-shadow var(--transition);
+
+        &:focus-within {
+            border-color: var(--brand);
+            box-shadow: var(--focus-ring);
+        }
+    }
+
+    &__chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+        margin: 0;
+        padding: 0;
+        list-style: none;
+    }
+
+    &__chip {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 3px var(--space-2) 3px 6px;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--text-body);
+        background: var(--sunken);
+        border: var(--border-width) solid var(--line);
+        border-radius: var(--radius-sm);
+    }
+
+    // the swatch matches the series colour, which the chart assigns by the same position
+    &__swatch {
+        flex: 0 0 auto;
+        width: 8px;
+        height: 8px;
+        border-radius: 2px;
+        background: var(--chart-8);
+    }
+
+    @for $index from 1 through 8 {
+        &__chip:nth-child(#{$index}) &__swatch {
+            background: var(--chart-#{$index});
+        }
+    }
+
+    &__chip-remove {
+        padding: 0;
+        font-size: 13px;
+        line-height: 1;
+        color: var(--text-faint);
+        background: none;
+        border: 0;
+        cursor: pointer;
+
+        &:hover,
+        &:focus-visible {
+            color: var(--text-body);
+        }
+    }
+
+    // what is typed is the rest of the field, and drops to its own line once the chips fill one
+    &__input {
+        flex: 1 1 12rem;
+        min-width: 0;
+        padding: 0;
+        font-family: var(--font-sans);
+        font-size: var(--text-sm);
+        line-height: 1.4;
+        color: var(--text-heading);
+        background: none;
+        border: 0;
+        outline: none;
+
+        &::placeholder {
+            color: var(--text-faint);
+        }
+    }
 
     &__menu {
         position: absolute;
@@ -740,153 +834,5 @@ a.chip:hover {
 
     &__dot {
         color: var(--text-faint);
-    }
-}
-
-// --- RepositorySelect -------------------------------------------------------------------------
-// select2 dressed as the design system's multi-select: each pick adds a chart series, and the swatch
-// on its chip carries the colour that series is drawn in.
-//
-// select2 ships its default theme inside `core`, and those rules are one class more specific than a
-// plain `.select2-container--default .thing`. Every override below therefore goes through
-// `.select2-selection--multiple` (or matches the theme's own compound selector) to reach it.
-.select2-container--default {
-    width: 100% !important;
-
-    .select2-selection--multiple {
-        min-height: 42px;
-        padding: calc(var(--space-2) - 2px) var(--space-3);
-        background-color: var(--surface-input);
-        border: var(--border-width) solid var(--input-border-color);
-        border-radius: var(--radius);
-        transition:
-            border-color var(--transition),
-            box-shadow var(--transition);
-
-        .select2-selection__rendered {
-            display: flex;
-            flex-wrap: wrap;
-            gap: var(--space-2);
-            align-items: center;
-            margin: 0;
-            padding: 0;
-            list-style: none;
-        }
-
-        .select2-selection__choice {
-            display: inline-flex;
-            align-items: center;
-            gap: var(--space-2);
-            // the theme positions the remove button absolutely over a 20px inset; the chip lays its
-            // three parts out in a row instead
-            position: static;
-            max-width: none;
-            overflow: visible;
-            margin: 0;
-            padding: 3px var(--space-2) 3px 6px;
-            font-family: var(--font-mono);
-            font-size: var(--text-xs);
-            color: var(--text-body);
-            background-color: var(--sunken);
-            border: var(--border-width) solid var(--line);
-            border-radius: var(--radius-sm);
-
-            // the swatch matches the series colour, which the chart assigns by selection order
-            &::before {
-                content: '';
-                flex: 0 0 auto;
-                width: 8px;
-                height: 8px;
-                border-radius: 2px;
-                background: var(--chart-8);
-            }
-
-            @for $index from 1 through 8 {
-                &:nth-child(#{$index})::before {
-                    background: var(--chart-#{$index});
-                }
-            }
-        }
-
-        .select2-selection__choice__display {
-            padding: 0;
-            cursor: pointer;
-        }
-
-        .select2-selection__choice__remove {
-            order: 2;
-            position: static;
-            margin: 0;
-            padding: 0;
-            font-size: 13px;
-            font-weight: var(--weight-body);
-            line-height: 1;
-            color: var(--text-faint);
-            background-color: transparent;
-            border: 0;
-            border-radius: 0;
-            cursor: pointer;
-
-            &:hover,
-            &:focus {
-                color: var(--text-body);
-                background-color: transparent;
-            }
-        }
-    }
-
-    &.select2-container--focus .select2-selection--multiple,
-    &.select2-container--open .select2-selection--multiple {
-        border-color: var(--brand);
-        box-shadow: var(--focus-ring);
-    }
-
-    .select2-search--inline .select2-search__field {
-        margin: 0;
-        font-family: var(--font-sans);
-        font-size: var(--text-sm);
-        line-height: 1.4;
-        color: var(--text-heading);
-
-        &::placeholder {
-            color: var(--text-faint);
-        }
-    }
-
-    .select2-dropdown {
-        background: var(--surface-card);
-        border: var(--border-width) solid var(--line);
-        border-radius: var(--radius);
-        box-shadow: var(--shadow-overlay);
-    }
-
-    .select2-search--dropdown .select2-search__field {
-        padding: var(--control-pad-y) var(--control-pad-x);
-        font-family: var(--font-sans);
-        font-size: var(--text-sm);
-        color: var(--text-heading);
-        border: var(--border-width) solid var(--input-border-color);
-        border-radius: var(--radius);
-        outline: none;
-    }
-
-    .select2-results__option {
-        padding: var(--space-2) var(--space-4);
-        font-family: var(--font-mono);
-        font-size: var(--text-sm);
-        color: var(--text-body);
-    }
-
-    // the menu is the list of what can be added, so what is in the chart already is not on it - the
-    // chips above it are where a repository is removed again
-    .select2-results__option--selected,
-    .select2-results__option[aria-selected='true'] {
-        display: none;
-    }
-
-    .select2-results__option--highlighted,
-    .select2-results__option--highlighted.select2-results__option--selectable {
-        color: var(--text-body);
-        background-color: var(--sunken);
     }
 }

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -1,7 +1,5 @@
-// Font Awesome is the design system's icon set; select2's core stylesheet is the layout its
-// multi-select needs before the design system dresses it up in _components.scss.
+// Font Awesome is the design system's icon set.
 @use '@fortawesome/fontawesome-free/css/all';
-@use 'select2/src/scss/core';
 
 @use 'tokens';
 @use 'base';

--- a/package.json
+++ b/package.json
@@ -7,11 +7,9 @@
         "chart.js": "^4.5",
         "chartjs-adapter-moment": "^1.0.0",
         "chartjs-plugin-zoom": "^2.2",
-        "jquery": "^4.0",
         "moment": "^2.29.4",
         "prettier": "^3.9",
         "sass": "^1.53.0",
-        "select2": "^4.1.0-rc.0",
         "vite": "^7.0.0"
     },
     "license": "MIT",

--- a/templates/chart.html.twig
+++ b/templates/chart.html.twig
@@ -107,14 +107,36 @@
                      # what is picked ends up in the query string. The headline says what it is, so the
                      # box needs no second one.
                      #}
-                    <div class="repository-picker">
-                        <select class="js-repository-select" name="repositories[]" multiple="multiple"
-                                aria-label="Repositories in this chart" data-chart-target="select">
-                            {# no whitespace around the name: select2 renders the raw text into its chips #}
+                    <div class="repository-picker" {{ stimulus_controller('repository-picker', {limit: chartLimit}) }}>
+                        {#
+                         # The state the box is a widget for: what is in the chart, and in which order it
+                         # is drawn. The chart reads this and redraws on its `change`, so it does not
+                         # care how a repository got in or out.
+                         #}
+                        <select name="repositories[]" multiple="multiple" hidden
+                                data-chart-target="select" data-repository-picker-target="select"
+                                data-action="change->chart#repick">
                             {% for repository in selection.options %}
                                 <option value="{{ repository.name }}" {{ repository in series ? 'selected="selected"' }}>{{ repository.name }}</option>
                             {% endfor %}
                         </select>
+                        {# the same box as the search on the start page, with room for more than one answer #}
+                        <div class="combobox">
+                            <div class="combobox__control" data-action="click->repository-picker#focus">
+                                <ul class="combobox__chips" data-repository-picker-target="chips"></ul>
+                                <input type="text" class="combobox__input"
+                                       placeholder="Search the report"
+                                       aria-label="Repositories in this chart"
+                                       autocomplete="off" autocapitalize="off" spellcheck="false"
+                                       role="combobox" aria-expanded="false" aria-autocomplete="list"
+                                       aria-controls="repository-suggestions"
+                                       data-repository-picker-target="input"
+                                       data-action="input->repository-picker#query focus->repository-picker#query keydown->repository-picker#navigate blur->repository-picker#close">
+                            </div>
+                            <ul class="combobox__menu" id="repository-suggestions" role="listbox"
+                                aria-label="Repositories the report carries"
+                                data-repository-picker-target="menu" hidden></ul>
+                        </div>
                         <p class="repository-picker__hint">
                             Up to {{ chartLimit }} at a time, one colour each.
                             <a href="{{ path('start') }}">Add a repository</a> the report does not carry yet.

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,9 +15,9 @@ export default defineConfig({
     css: {
         preprocessorOptions: {
             scss: {
-                // Bootstrap 5.3, Font Awesome and select2 are all still written against the
-                // @import based Sass, so their own deprecation warnings say nothing about this
-                // codebase - hundreds of lines of them per build, none of them actionable here.
+                // Font Awesome is still written against the @import based Sass, so its own
+                // deprecation warnings say nothing about this codebase - hundreds of lines of
+                // them per build, none of them actionable here.
                 quietDeps: true,
             },
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -507,11 +507,6 @@ is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
-jquery@^4.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-4.0.0.tgz#95c33ac29005ff72ec444c5ba1cf457e61404fbb"
-  integrity sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==
-
 moment@^2.29.4:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
@@ -600,11 +595,6 @@ sass@^1.53.0:
     source-map-js ">=0.6.2 <2.0.0"
   optionalDependencies:
     "@parcel/watcher" "^2.4.1"
-
-select2@^4.1.0-rc.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/select2/-/select2-4.1.0.tgz#8b037e02a3c025beda07fed7f9ecc7d298036e1a"
-  integrity sha512-i9KalWOP4/LRRGc8+rj2krNm0ZqP14cV+j1TRCEBSsOhCPkKH8rYZ2MCRXcgvqIqN+llqGci0hj9aVkCMvL0+g==
 
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
The picker above the chart was select2, whose menu highlights whatever the pointer passes over and then fights the keyboard for the same row - the brittle hover this replaces. The start page already has a box that does not do that, so the chart gets that one.

What both boxes need lives in `assets/combobox.js`: the rows, opening and closing the menu, and the keyboard that walks it. What a row says and what picking one means stays with the box that built it - `search_controller.js` asks the server what an input means, `repository_picker_controller.js` picks from what the report already carries. Only the keyboard highlights a row (`.is-active`); picking happens on `mousedown`, before the blur that closes the menu can race it.

The picker adds what a second answer needs:

- a chip per line, carrying the colour of its series - which is why a pick moves its option to the end of the `<select>` behind it, the same rule `moveToEnd()` kept
- that select stays the state, not a widget: it is what the chart reads, and its `change` is what redraws it, however a repository got in or out
- backspace on an empty field takes the last chip out, the × on a chip takes that one
- the menu says which of the three empty answers it means: the chart is full at `CHART_LIMIT`, the report is in it already, or nothing goes by that name

`select2` and `jquery` leave with it, and so does the `turbo:before-cache` teardown they needed - every box renders by replacing what is there, so a cached page comes back as itself rather than doubled.

## Checked

Drove a headless Chrome over the built assets:

- picking with enter and with the pointer, arrow wrapping through the input, escape, backspace, the × on a chip - chips, `<select>`, query string, headline and document title follow each one
- hovering a row does not move what the keyboard is on
- chip swatches equal the series colours the chart draws
- turbo back/forward across start ↔ chart with the box left open: one box, one canvas, no duplicated chips, no console errors
- the start page box is unchanged after the refactor

`vendor/bin/phpunit` (113 tests), phpstan, php-cs-fixer, `lint:twig`, `lint:yaml`, `lint:container`, `yarn check-style` and `yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)