### PR TITLE
Measure one repository where it can be watched

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ bin/console doctrine:migrations:diff              # after changing an entity
 bin/console messenger:consume async -vv           # the analysis queue
 bin/console messenger:consume scheduler_default   # the nightly release scan and star refresh
 bin/console messenger:stats                       # what is still queued
+bin/console app:repository:analyse moodle/moodle  # measure one repository here instead of in a worker
 bin/console debug:scheduler                       # next run of the recurring messages
 
 # frontend — Vite, wired into Twig by symfony/reprise
@@ -75,6 +76,17 @@ Submitting is what dispatches `AnalyseRepository`, so nothing queues the seed re
 `app:releases:scan` is how a run that was interrupted is picked up again, since it asks github.com which
 releases are still missing. `app:data:fix` needs the queue to be empty (`messenger:stats`) to see all the
 data.
+
+`app:repository:analyse <owner/repository>` is the exception to all of that: it runs `RepositoryAnalyser`
+**in the console process** rather than dispatching, which is the only way to watch a repository that does
+not get through the queue. A worker measures where nobody looks, and an analysis that dies without
+throwing — a memory limit, an OOM kill — is never acked, so the transport hands the same message back and
+it dies again on the next delivery, forever, while the repository stays `analysed IS NULL` and the report
+keeps calling it queued. Run on the console it can be given `php -d memory_limit=…`, watched release by
+release and stopped. It takes the same `WorkingCopyLock` a worker takes, so it refuses rather than
+measuring against a checkout somebody else is rewriting, and prints the peak memory of the run since that
+is usually what is being chased. `--queue` dispatches instead, for the one repository the nightly scan
+would skip.
 
 Filling a fresh instance with more than the fixtures is `app:repository:submit --file --wait`, pointed at
 `data/top-php-repositories.txt` (an operator list, not part of the dataset definition — nothing reads it on

--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ symfony console app:data:fix -vv
 it, and `app:releases:scan` picks up whatever a run left unfinished, since it asks github.com for the
 releases a repository is still missing.
 
+One repository that will not get through the queue is `app:repository:analyse`, which measures it right
+here instead of dispatching it:
+
+```bash
+symfony console app:repository:analyse moodle/moodle -vv
+```
+
+That is what a worker would have done, only where it can be watched, given a memory limit and stopped -
+an analysis a worker loses to a memory limit is never acked, so it comes back on the next delivery and
+fails the same way, while the report keeps showing the repository as queued. `--queue` dispatches it for a
+worker instead.
+
 Schema changes
 --------------
 

--- a/src/Command/RepositoryAnalyseCommand.php
+++ b/src/Command/RepositoryAnalyseCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\ComplexityReport\Exception\SubmissionFailed;
+use App\ComplexityReport\GitHub\RepositoryIdentifier;
+use App\ComplexityReport\RepositoryAnalyser;
+use App\ComplexityReport\WorkingCopyLock;
+use App\Entity\Repository;
+use App\Message\AnalyseRepository;
+use App\Repository\RepositoryRepository;
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Measures one named repository, in this process.
+ *
+ * Everything else that analyses goes through the queue: submitting dispatches, the nightly scan dispatches
+ * what released. That is right for a report that fills itself and wrong for the one repository that does
+ * not get through - a worker measures where nobody watches, and a repository that dies mid-analysis is
+ * handed back to the transport and dies again on the next delivery. This is the same analysis run where it
+ * can be watched, given a memory limit and stopped.
+ */
+#[AsCommand('app:repository:analyse', 'Measures the releases of a repository that are missing from the report')]
+final readonly class RepositoryAnalyseCommand
+{
+    public function __construct(
+        private RepositoryRepository $repositoryRepository,
+        private RepositoryAnalyser $repositoryAnalyser,
+        private WorkingCopyLock $workingCopyLock,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @param string[] $repositories
+     */
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Argument('One or more repositories the report already carries, e.g. "moodle/moodle"')]
+        array $repositories,
+        #[Option('Queue the analysis for a worker instead of running it here')]
+        bool $queue = false,
+    ): int {
+        $io->title('Analysing repositories');
+
+        $failed = false;
+
+        foreach ($repositories as $submitted) {
+            try {
+                $repository = $this->load($submitted);
+            } catch (SubmissionFailed $exception) {
+                $io->error($exception->getMessage());
+                $failed = true;
+                continue;
+            }
+
+            if ($queue) {
+                $this->messageBus->dispatch(new AnalyseRepository($repository->getId()));
+                $io->text(sprintf(' * <options=bold>%s</> queued for analysis', $repository->getName()));
+
+                continue;
+            }
+
+            $failed = !$this->analyse($io, $repository) || $failed;
+        }
+
+        if ($queue) {
+            $io->success('Queued - run messenger:consume async to work it off.');
+        }
+
+        return $failed ? 1 : 0;
+    }
+
+    /**
+     * @throws SubmissionFailed when the input does not identify a repository of this report
+     */
+    private function load(string $input): Repository
+    {
+        $identifier = (string) RepositoryIdentifier::fromInput($input);
+        $repository = $this->repositoryRepository->findOneByName($identifier);
+
+        if (!$repository instanceof Repository) {
+            // analysing is for what is in the report already - submitting is how something gets in
+            throw SubmissionFailed::notSubmitted($identifier);
+        }
+
+        return $repository;
+    }
+
+    private function analyse(SymfonyStyle $io, Repository $repository): bool
+    {
+        $io->section($repository->getName());
+
+        // the same lock a worker takes: two checkouts of one working copy measure each other's code
+        $lock = $this->workingCopyLock->create($repository);
+
+        if (!$lock->acquire()) {
+            $io->warning(sprintf('%s is being analysed already - stop the worker holding it or wait.', $repository->getName()));
+
+            return false;
+        }
+
+        try {
+            $measured = $this->repositoryAnalyser->analyse($repository);
+        } finally {
+            $lock->release();
+        }
+
+        $io->text(sprintf('Measured %d new release(s), peak memory %d MB.', $measured, intdiv(memory_get_peak_usage(true), 1024 * 1024)));
+
+        return true;
+    }
+}


### PR DESCRIPTION
There is no way to analyse a single repository today. `app:releases:scan` fans out over everything, and
`app:repository:submit` answers a repository the report already carries with `Submission::known` without
dispatching anything - so a repository that will not get through the queue has no handle on it at all.

`app:repository:analyse <owner/repository>` runs `RepositoryAnalyser` in the console process instead of
dispatching it. That is what a worker would have done, only where it can be given `php -d memory_limit=…`,
watched release by release and stopped - which matters because an analysis that dies *without throwing* (a
memory limit, an OOM kill) is never acked, so the transport hands the same message back and it dies again
on the next delivery, forever, while the repository stays `analysed IS NULL` and the report keeps calling
it queued.

It takes the same `WorkingCopyLock` a worker takes, so it refuses rather than measuring against a checkout
somebody else is rewriting, and prints the peak memory of the run since that is usually what is being
chased. `--queue` dispatches instead, for the one repository the nightly scan would skip.

Checks: php-cs-fixer, phpstan (level 8), phpunit (113 tests), lint:container - all green. No test of its
own: like every other command it needs a booted kernel, which is not covered yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)