### PR TITLE
Say what a complexity number means, everywhere it is shown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,12 @@ optional profile fields and named the wrong account as often as the right one.
   submission is what queued it, so pasting a known repository is how people look it up — it is answered
   from the database, before github.com is asked at all.
 - `RepositoryRefresher` — re-reads stars and metadata for everything submitted.
+- `ComplexityLevel` — the four risk bands a cyclomatic complexity is read in (1–10 simple, 11–20
+  moderate, 21–50 complex, above that untestable). It is what the scale in the footer is printed from and
+  what colours every complexity the report shows, so the bands are written down once — the report measures
+  averages, so a band ends where its number does. `chart_controller.js` mirrors the thresholds, because
+  the release analysis is built in the browser; like the naming rule of the chart, the mirror only holds
+  as long as the rule stays this small.
 - `Trend/*` — the whole report rolled up into one figure per time frame (`TrendWindow`: YTD, 12 months,
   5 years, all time), shown in the hero of the start page. `TrendCalculator` is pure: it takes a list of
   `ReleasePoint`s and the current time and returns `Trend` value objects, which is why the rules live
@@ -220,6 +226,16 @@ applies the same rule to the headline, its github.com link and the document titl
 changes, which is why the rule has to stay this small. A repository has a chart from the moment it is
 submitted: no releases yet means no lines but a status telling the visitor it is queued or being measured
 right now - the one state the browser cannot rename, since nothing can be picked in it.
+
+The **scale** (`templates/complexity_scale.html.twig`) closes the footer both screens carry, across both
+columns that explain the report rather than inside the one about the metric - at half the width every band
+would set its risk in two lines. It is the four bands of `ComplexityLevel` over the ramp they run through,
+the bands washed white so their ranges stay readable and only the hairlines between them and the strip
+below them carry the colour at full strength. On a phone the ramp turns and the bands stack on it,
+which is the same reading in the direction there is room for. Every complexity elsewhere is marked with a
+dot in the colour of its band - on a card it stands where the `Ø` stood, since a metric leads with one
+glyph and the row has no width to spare, and in the release analysis it leads the numbers that are
+complexities rather than changes to one.
 
 Routes are distinguished by `priority`, since `{organization}` and the slug of a repository both match
 whatever is left: `chart`/`search`/`submit` (3) > `repository` (2, `owner/repository`, returns one line of

--- a/assets/controllers/chart_controller.js
+++ b/assets/controllers/chart_controller.js
@@ -55,6 +55,21 @@ function trend(value, digits, label) {
     return node;
 }
 
+/*
+ * The risk bands the footer prints, mirrored from `ComplexityLevel` because the release analysis is
+ * built here in the browser rather than rendered. Like the naming rule above, the mirror only holds as
+ * long as the rule stays this small - four numbers and the band above the last of them.
+ */
+const LEVELS = [
+    [10, 'simple'],
+    [20, 'moderate'],
+    [50, 'complex'],
+];
+const level = (value) => LEVELS.find(([limit]) => value <= limit)?.[1] ?? 'untestable';
+
+// a measured complexity carrying the dot of its band, the way the cards of the start page carry it
+const complexity = (value) => element('span', `level level--${level(value)}`, decimal(value, 2));
+
 function row(label, value, hint) {
     const node = element('div', 'analysis__row');
     const definition = element('dd', 'analysis__value');
@@ -464,7 +479,7 @@ export default class extends Controller {
             group('Release', [
                 row('Released', day(tag.date)),
                 row('Lines of code (LOC)', count(tag.loc)),
-                row('Ø cyclomatic complexity', decimal(tag.y, 2)),
+                row('Ø cyclomatic complexity', complexity(tag.y)),
             ]),
             previous
                 ? group(`Compared to ${previous.name}`, [
@@ -481,8 +496,8 @@ export default class extends Controller {
             // the first release is in the head, above every group - it says what the repository is
             group(`All ${tags.length} releases`, [
                 row('Analysed releases', count(tags.length)),
-                row('Lowest Ø complexity', decimal(Math.min(...complexities), 2)),
-                row('Highest Ø complexity', decimal(Math.max(...complexities), 2)),
+                row('Lowest Ø complexity', complexity(Math.min(...complexities))),
+                row('Highest Ø complexity', complexity(Math.max(...complexities))),
             ]),
         ];
 

--- a/assets/styles/_base.scss
+++ b/assets/styles/_base.scss
@@ -392,7 +392,7 @@ canvas {
 
 // The footer of every page: hairline above, mono-quiet copy. Above the credits, the two columns that
 // explain the report - running text rather than the small print the row below it is set in, since it
-// is meant to be read once.
+// is meant to be read once - and the scale the numbers themselves are read against, closing them.
 .site-footer {
     flex: 0 0 auto;
     margin-top: var(--space-9);
@@ -432,6 +432,12 @@ canvas {
 
     &__links {
         color: var(--text-muted);
+    }
+
+    // The scale closes the block across both columns: in half the width every band would set its risk
+    // in two lines, and it is what both columns lead to anyway.
+    &__scale {
+        grid-column: 1 / -1;
     }
 
     &__inner {

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -850,3 +850,110 @@ a.chip:hover {
         color: var(--text-faint);
     }
 }
+
+// --- Level ------------------------------------------------------------------------------------
+// Where one measured complexity sits on the scale in the footer, as a dot in the colour of its band
+// in front of the number. The number keeps its own ink: green and clay already say "improved" and
+// "got worse" in the very same line, and the band is a different statement.
+.level::before {
+    content: '';
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    margin-right: 6px;
+    background: var(--level-color);
+    border-radius: 50%;
+}
+
+.level--simple {
+    --level-color: var(--level-simple);
+}
+
+.level--moderate {
+    --level-color: var(--level-moderate);
+}
+
+.level--complex {
+    --level-color: var(--level-complex);
+}
+
+.level--untestable {
+    --level-color: var(--level-untestable);
+}
+
+// --- Scale ------------------------------------------------------------------------------------
+// The four risk bands of cyclomatic complexity, drawn as one ramp rather than four boxes: the ramp
+// is the background of the whole strip, the bands are washes of white laid over it, so each band
+// keeps a tint of where it sits while the colour itself stays continuous. What is left uncovered -
+// the hairline gaps between the bands and the strip below them - is the ramp at full strength.
+.scale {
+    // one stop list for both directions: the bands are quarters, so the ramp turns at 25/50/75 and
+    // is given a few percent on either side to do it in
+    --scale-ramp:
+        var(--level-simple) 19%, var(--level-moderate) 27%, var(--level-moderate) 46%, var(--level-complex) 54%,
+        var(--level-complex) 73%, var(--level-untestable) 81%;
+
+    padding-bottom: 6px;
+    background-image: linear-gradient(90deg, var(--scale-ramp));
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+
+    &__bands {
+        display: flex;
+        gap: 3px;
+    }
+
+    &__band {
+        flex: 1 1 0;
+        padding: var(--space-3) var(--space-2);
+        text-align: center;
+        // the wash: opaque enough to read text on, thin enough to keep the band's own colour
+        background: rgb(255 255 255 / 0.84);
+    }
+
+    &__range {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        font-weight: var(--weight-medium);
+        font-variant-numeric: tabular-nums;
+        color: var(--text-heading);
+    }
+
+    &__risk {
+        display: block;
+        margin-top: 2px;
+        font-size: var(--text-xs);
+        line-height: 1.4;
+        color: var(--text-muted);
+    }
+}
+
+// Four columns of prose do not survive a phone, so the strip turns: the ramp runs top to bottom and
+// the bands stack on it, which is the same reading in the direction there is room for.
+@media (max-width: 640px) {
+    .scale {
+        padding-right: 6px;
+        padding-bottom: 0;
+        background-image: linear-gradient(180deg, var(--scale-ramp));
+
+        &__bands {
+            flex-direction: column;
+        }
+
+        &__band {
+            padding: var(--space-2) var(--space-3);
+            text-align: left;
+        }
+
+        // the range and what it means fit next to each other once a band is a full row wide
+        &__range,
+        &__risk {
+            display: inline;
+        }
+
+        &__risk {
+            margin-left: var(--space-2);
+        }
+    }
+}

--- a/assets/styles/_tokens.scss
+++ b/assets/styles/_tokens.scss
@@ -57,6 +57,13 @@
     --mark-mid: #c9a24d;
     --mark-high: #d06a5a;
 
+    // The four risk bands cyclomatic complexity is read in (`ComplexityLevel`), the mark's ramp with a
+    // step inserted between its first two bars - the same green-to-clay reading, one level wider
+    --level-simple: var(--mark-low);
+    --level-moderate: #7a9a4e;
+    --level-complex: var(--mark-mid);
+    --level-untestable: var(--mark-high);
+
     // Chart series - eight muted, evenly-weighted lines, assigned by position
     --chart-1: #2f3a49;
     --chart-2: #c05b4d;

--- a/src/ComplexityReport/ComplexityLevel.php
+++ b/src/ComplexityReport/ComplexityLevel.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport;
+
+/**
+ * The risk bands a cyclomatic complexity is read in - the scale the footer prints and the colour every
+ * complexity in the report is marked with, so a number says where it stands before it is compared to
+ * anything.
+ *
+ * The cases are in the order the scale runs, which is what the ramp behind it is drawn from: the report
+ * measures averages, so a band ends where its number does and the next one starts right after it.
+ */
+enum ComplexityLevel: string
+{
+    case Simple = 'simple';
+    case Moderate = 'moderate';
+    case Complex = 'complex';
+    case Untestable = 'untestable';
+
+    public static function of(float $complexity): self
+    {
+        return match (true) {
+            $complexity <= 10.0 => self::Simple,
+            $complexity <= 20.0 => self::Moderate,
+            $complexity <= 50.0 => self::Complex,
+            default => self::Untestable,
+        };
+    }
+
+    public function range(): string
+    {
+        return match ($this) {
+            self::Simple => '1–10',
+            self::Moderate => '11–20',
+            self::Complex => '21–50',
+            self::Untestable => '> 50',
+        };
+    }
+
+    public function risk(): string
+    {
+        return match ($this) {
+            self::Simple => 'Simple procedure, little risk',
+            self::Moderate => 'More complex, moderate risk',
+            self::Complex => 'Complex, high risk',
+            self::Untestable => 'Untestable code, very high risk',
+        };
+    }
+}

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Twig;
 
+use App\ComplexityReport\ComplexityLevel;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 final class AppExtension extends AbstractExtension
 {
@@ -16,7 +18,31 @@ final class AppExtension extends AbstractExtension
             new TwigFilter('compact_number', [$this, 'formatCompactNumber']),
             new TwigFilter('signed_percent', [$this, 'formatSignedPercent']),
             new TwigFilter('trend_tone', [$this, 'trendTone']),
+            new TwigFilter('complexity_level', [$this, 'complexityLevel']),
         ];
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('complexity_levels', [$this, 'complexityLevels']),
+        ];
+    }
+
+    /**
+     * Where a measured complexity sits on the scale the footer prints.
+     */
+    public function complexityLevel(float $complexity): ComplexityLevel
+    {
+        return ComplexityLevel::of($complexity);
+    }
+
+    /**
+     * @return ComplexityLevel[] the whole scale, in the order it runs
+     */
+    public function complexityLevels(): array
+    {
+        return ComplexityLevel::cases();
     }
 
     public function formatStars(int $stars): string

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -49,7 +49,8 @@
          # What the chart does not say by itself, on every page rather than on a page of its own: how a
          # number gets into it, and what that number is worth. The second half is the one that matters -
          # a line going up reads as a verdict unless it says next to it that this is one metric among
-         # many, and that parts of the data are known to be off.
+         # many, and that parts of the data are known to be off. The scale closing the block is where
+         # the numbers themselves are read, and it stands under both columns because both lead to it.
          #}
         <footer class="site-footer">
             <div class="wrap site-footer__about">
@@ -112,6 +113,10 @@
                         <a href="https://ieeexplore.ieee.org/document/1702388" target="_blank" rel="noreferrer">McCabe, A Complexity Measure (1976)</a>,
                         <a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication500-235.pdf" target="_blank" rel="noreferrer">NIST 500-235</a>.
                     </p>
+                </section>
+                <section class="site-footer__section site-footer__scale">
+                    <h2 class="eyebrow">Complexity levels</h2>
+                    {{ include('complexity_scale.html.twig') }}
                 </section>
             </div>
             <div class="site-footer__inner">

--- a/templates/complexity_scale.html.twig
+++ b/templates/complexity_scale.html.twig
@@ -1,0 +1,19 @@
+{#
+ # What the numbers of the report mean: the four risk bands a cyclomatic complexity is read in, laid
+ # out over the ramp they run through - the bands are the labels, the ramp is only visible between
+ # them and under them, which is why the ranges stay readable and the colour is still the message.
+ #
+ # The bands come from `ComplexityLevel`, in the order the enum lists them, because that order is what
+ # the ramp behind them is drawn from - and because the dot next to every complexity in the report is
+ # coloured by the same case.
+ #}
+<div class="scale">
+    <div class="scale__bands">
+        {% for level in complexity_levels() %}
+            <div class="scale__band scale__band--{{ level.value }}">
+                <span class="scale__range">{{ level.range }}</span>
+                <span class="scale__risk">{{ level.risk }}</span>
+            </div>
+        {% endfor %}
+    </div>
+</div>

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -10,9 +10,16 @@
             <i class="fas fa-star"></i>{{ repository.stars|stars }}
         </span>
     {% endset %}
+    {#
+     # The dot says which band of the footer scale this average falls into, and it stands where the Ø
+     # stood: a metric leads with one glyph, and on a card there is room for one - the title says in
+     # words what the dot means and that the number is an average.
+     #}
     {% set complexity %}
-        <span class="metric" title="Average cyclomatic complexity of the latest analysed release">
-            <span class="metric__label">Ø</span>{{ repository.complexity|number_format(2) }}
+        {% set level = repository.complexity|complexity_level %}
+        <span class="metric level level--{{ level.value }}"
+              title="Average cyclomatic complexity of the latest analysed release - {{ level.range }}: {{ level.risk|lower }}">
+            {{- repository.complexity|number_format(2) -}}
         </span>
     {% endset %}
     {% set linesOfCode %}

--- a/tests/ComplexityReport/ComplexityLevelTest.php
+++ b/tests/ComplexityReport/ComplexityLevelTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\ComplexityReport;
+
+use App\ComplexityReport\ComplexityLevel;
+use PHPUnit\Framework\TestCase;
+
+final class ComplexityLevelTest extends TestCase
+{
+    /**
+     * @dataProvider complexities
+     */
+    public function testReadsAComplexityAsTheBandItFallsInto(float $complexity, ComplexityLevel $expected): void
+    {
+        self::assertSame($expected, ComplexityLevel::of($complexity));
+    }
+
+    /**
+     * @return iterable<string, array{float, ComplexityLevel}>
+     */
+    public static function complexities(): iterable
+    {
+        yield 'the lowest a measured average can be' => [1.0, ComplexityLevel::Simple];
+        yield 'a typical library' => [6.54, ComplexityLevel::Simple];
+        yield 'the last of the first band' => [10.0, ComplexityLevel::Simple];
+        // the report measures averages, so a band ends where its number does
+        yield 'just past it' => [10.01, ComplexityLevel::Moderate];
+        yield 'the last of the second band' => [20.0, ComplexityLevel::Moderate];
+        yield 'past the second band' => [20.5, ComplexityLevel::Complex];
+        yield 'the last of the third band' => [50.0, ComplexityLevel::Complex];
+        yield 'past every band there is' => [50.1, ComplexityLevel::Untestable];
+    }
+
+    public function testPrintsTheWholeScaleInTheOrderItRuns(): void
+    {
+        $ranges = array_map(static fn (ComplexityLevel $level) => $level->range(), ComplexityLevel::cases());
+
+        self::assertSame(['1–10', '11–20', '21–50', '> 50'], $ranges);
+    }
+}


### PR DESCRIPTION
Like the scale on [decomplex.me](https://decomplex.me), in our own palette and with the McCabe risk bands.

## What is in it

**The scale, closing the footer of every page** — the four bands (`1–10` simple, `11–20` moderate,
`21–50` complex, `> 50` untestable) laid over the ramp they run through, under the two columns that
explain the report rather than inside the one about the metric: at half the width every band would set its
risk in two lines. The bands are washes of white over the ramp, so the ranges stay readable and the colour
survives only in the hairlines between them and in the strip below them. The ramp is the mark's own
green-to-clay with one step inserted, so nothing new enters the palette. On a phone the ramp turns and the
bands stack on it.

**A dot in the colour of its band on every complexity the report shows** — on the cards of the rankings it
takes the place the `Ø` had (a metric leads with one glyph, and the row has no width to spare: with both,
the GitHub link wrapped off the WordPress card), and in the release analysis of the chart it leads the
numbers that are complexities rather than changes to one.

**One place the bands are written down** — `ComplexityLevel`, which the scale is printed from and the
cards are coloured by. `chart_controller.js` mirrors the thresholds, since the release analysis is built
in the browser; the same trade the naming rule of the chart already makes.

## Checks

Rebased onto `main` (the footer text of #35, the release head of #34 and the chart box of #37 are all
kept). `php-cs-fixer`, `phpstan`, `phpunit` (126 tests, 9 of them new for the band boundaries),
`lint:twig`, `lint:container` and `prettier` all pass. Rendered and read on both screens after the rebase,
desktop and 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)