### PR TITLE
Put what explains the report where it is read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ optional profile fields and named the wrong account as often as the right one.
   from the database, before github.com is asked at all.
 - `RepositoryRefresher` — re-reads stars and metadata for everything submitted.
 - `ComplexityLevel` — the four risk bands a cyclomatic complexity is read in (1–10 simple, 11–20
-  moderate, 21–50 complex, above that untestable). It is what the scale in the footer is printed from and
+  moderate, 21–50 complex, above that untestable). It is what the scale of the about block is printed from and
   what colours every complexity the report shows, so the bands are written down once — the report measures
   averages, so a band ends where its number does. `chart_controller.js` mirrors the thresholds, because
   the release analysis is built in the browser; like the naming rule of the chart, the mirror only holds
@@ -209,9 +209,12 @@ an unknown repository, a fork, too little PHP - stays a flash on the start page,
 ends on the page of its repository, whether it was just queued or has been in the report for years.
 
 **Web** (`src/Controller/ReportController`) — two screens: `start` renders the trend in the hero, the
-submit form, the rankings, a line of GitHub owners (only those grouping more than one measured
-repository - a single one is the repository the rankings already link to) and what is still queued, and
-`chart` is everything
+submit form, the rankings, then the block explaining the report, and below it the two quiet lists that
+close the page - a line of GitHub owners (only those grouping more than one measured repository - a
+single one is the repository the rankings already link to) and the latest additions, `LATEST_LIMIT`
+repositories newest submission first, measured or not: the rankings only carry what has numbers, so this
+is the one place a repository shows up the day it was added, with a status on its chip while it is
+`queued` or being analysed. `chart` is everything
 else. There is **one** chart page, not one per organization: `?repositories=symfony/console,nikic/iter`
 says which repositories it draws, in that order, up to `CHART_LIMIT` (the chart has eight colours), and
 anything the report carries can be added to them. Without a selection it opens on the most starred.
@@ -227,9 +230,17 @@ changes, which is why the rule has to stay this small. A repository has a chart 
 submitted: no releases yet means no lines but a status telling the visitor it is queued or being measured
 right now - the one state the browser cannot rename, since nothing can be picked in it.
 
-The **scale** (`templates/complexity_scale.html.twig`) closes the footer both screens carry, across both
-columns that explain the report rather than inside the one about the metric - at half the width every band
-would set its risk in two lines. It is the four bands of `ComplexityLevel` over the ramp they run through,
+What the report does not say by itself is `templates/about.html.twig`: how a number gets into it, what
+that number is worth, and the scale it is read against. It is not the footer anymore - the footer is the
+credits - but a band each screen places itself, since where it belongs differs: on the start page it
+stands under the rankings and before the lists closing them, on the chart page it ends the screen,
+rendered outside `<main>` so it is the element right before the credits and `.about + .site-footer`
+closes the two into the one band they were.
+
+The **scale** (`templates/complexity_scale.html.twig`) opens that block, across both columns that explain
+the report rather than inside the one about the metric - it is what every number of the report is read
+against, so it comes before the texts, and at half the width every band would set its risk in two lines.
+It is the four bands of `ComplexityLevel` over the ramp they run through,
 the bands washed white so their ranges stay readable and only the hairlines between them and the strip
 below them carry the colour at full strength. On a phone the ramp turns and the bands stack on it,
 which is the same reading in the direction there is room for. Every complexity elsewhere is marked with a

--- a/assets/styles/_base.scss
+++ b/assets/styles/_base.scss
@@ -390,58 +390,16 @@ canvas {
     }
 }
 
-// The footer of every page: hairline above, mono-quiet copy. Above the credits, the two columns that
-// explain the report - running text rather than the small print the row below it is set in, since it
-// is meant to be read once - and the scale the numbers themselves are read against, closing them.
+// The credits under every page: hairline above, mono-quiet small print. What used to stand above them
+// is `.about` in _components.scss, which the screens place themselves - where it ends one, the rule
+// below drops this hairline so the two read as the one band they were.
 .site-footer {
     flex: 0 0 auto;
     margin-top: var(--space-9);
     background: var(--surface-band);
     border-top: var(--border-width) solid var(--line);
 
-    &__about {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: var(--space-7);
-        padding-top: var(--space-7);
-        padding-bottom: var(--space-6);
-    }
-
-    &__section {
-        h2 {
-            margin-bottom: var(--space-3);
-        }
-
-        p {
-            margin: 0 0 var(--space-3);
-            font-size: var(--text-sm);
-            line-height: var(--leading-body);
-            color: var(--text-body);
-        }
-
-        p:last-child {
-            margin-bottom: 0;
-        }
-
-        code {
-            font-family: var(--font-mono);
-            font-size: 0.92em;
-            color: var(--text-heading);
-        }
-    }
-
-    &__links {
-        color: var(--text-muted);
-    }
-
-    // The scale closes the block across both columns: in half the width every band would set its risk
-    // in two lines, and it is what both columns lead to anyway.
-    &__scale {
-        grid-column: 1 / -1;
-    }
-
     &__inner {
-        border-top: var(--border-width) solid var(--line);
         display: flex;
         flex-wrap: wrap;
         gap: var(--space-2);
@@ -459,18 +417,19 @@ canvas {
     }
 }
 
+// Where the about block ends a screen it is the element right before the credits: same ground, so
+// only one hairline between them and no gap - which is the footer the site had.
+.about + .site-footer {
+    margin-top: 0;
+    border-top: 0;
+}
+
 // Under 720px the lockup stacks above the nav row, which scrolls sideways instead of wrapping.
 @media (max-width: 720px) {
     .site-header__inner {
         flex-direction: column;
         align-items: flex-start;
         gap: var(--space-3);
-    }
-
-    // and the two explaining columns become two blocks, read one after the other
-    .site-footer__about {
-        grid-template-columns: minmax(0, 1fr);
-        gap: var(--space-6);
     }
 }
 

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -384,6 +384,17 @@
     color: var(--text-muted);
     background: var(--surface-muted);
     border-radius: var(--radius-sm);
+
+    // where a repository stands when it does not stand in the report yet - only rendered while there
+    // is something to say, so a chip without it is one that has its numbers
+    &__status {
+        margin-left: var(--space-2);
+        padding-left: var(--space-2);
+        color: var(--text-faint);
+        text-transform: uppercase;
+        letter-spacing: var(--tracking-eyebrow);
+        border-left: 1px solid var(--line-strong);
+    }
 }
 
 a.chip:hover {
@@ -955,5 +966,71 @@ a.chip:hover {
         &__risk {
             margin-left: var(--space-2);
         }
+    }
+}
+
+// --- About ------------------------------------------------------------------------------------
+// The block that explains the report, on the ground of a band across the full width, wherever a
+// screen places it. The scale opens it across both columns - it is what every number of the report
+// is read against, and at half the width every band would set its risk in two lines - and under it
+// the two texts run as running copy rather than as the small print of the credits below.
+.about {
+    flex: 0 0 auto;
+    margin-top: var(--space-9);
+    background: var(--surface-band);
+    border-top: var(--border-width) solid var(--line);
+    border-bottom: var(--border-width) solid var(--line);
+
+    &__inner {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--space-7);
+        padding-top: var(--space-7);
+        padding-bottom: var(--space-6);
+    }
+
+    &__scale {
+        grid-column: 1 / -1;
+    }
+
+    &__section {
+        h2 {
+            margin-bottom: var(--space-3);
+        }
+
+        p {
+            margin: 0 0 var(--space-3);
+            font-size: var(--text-sm);
+            line-height: var(--leading-body);
+            color: var(--text-body);
+        }
+
+        p:last-child {
+            margin-bottom: 0;
+        }
+
+        code {
+            font-family: var(--font-mono);
+            font-size: 0.92em;
+            color: var(--text-heading);
+        }
+    }
+
+    &__links {
+        color: var(--text-muted);
+    }
+
+    // quiet like the copy they sit in - this block is read, not navigated
+    a {
+        color: var(--text-muted);
+        border-bottom: 1px solid var(--line-strong);
+    }
+}
+
+// the two explaining columns become two blocks, read one after the other
+@media (max-width: 720px) {
+    .about__inner {
+        grid-template-columns: minmax(0, 1fr);
+        gap: var(--space-6);
     }
 }

--- a/assets/styles/_screens.scss
+++ b/assets/styles/_screens.scss
@@ -46,17 +46,15 @@
     color: var(--text-muted);
 }
 
-// The GitHub accounts under the rankings: a quiet line of links, not a section of its own.
+// The GitHub accounts behind the repositories: a quiet line of links, not a section of its own -
+// which is why it carries no rule above it either, the band it follows is separation enough.
 .owner-line {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-1) var(--space-4);
     align-items: baseline;
-    margin-top: var(--space-6);
-    padding-top: var(--space-5);
     font-size: var(--text-sm);
     color: var(--text-muted);
-    border-top: var(--border-width) solid var(--line);
 
     &__label {
         font-family: var(--font-mono);

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -40,6 +40,11 @@ final class ReportController extends AbstractController
      */
     private const int SEARCH_LIMIT = 8;
 
+    /**
+     * Number of recently submitted repositories the start page closes with.
+     */
+    private const int LATEST_LIMIT = 12;
+
     #[Route('', name: 'start', methods: 'GET')]
     public function start(
         RepositoryRepository $repositoryRepository,
@@ -58,7 +63,7 @@ final class ReportController extends AbstractController
             'rankings' => $rankings,
             'hasData' => [] !== $analysed,
             'organizations' => $organizationRepository->findWithSeveralRepositories(),
-            'pending' => $repositoryRepository->findPending(),
+            'latest' => $repositoryRepository->findLatest(self::LATEST_LIMIT),
             'statistics' => $statisticsLoader->load(),
             'trends' => $trendLoader->load(),
             'chartLimit' => self::CHART_LIMIT,

--- a/src/Repository/RepositoryRepository.php
+++ b/src/Repository/RepositoryRepository.php
@@ -140,16 +140,19 @@ final class RepositoryRepository extends ServiceEntityRepository
     }
 
     /**
-     * Submitted repositories that are waiting for their first analysis.
+     * What was submitted last, newest first - measured or not, since a repository is part of the report
+     * from the moment somebody added it, and the rankings only carry what has numbers.
      *
      * @return list<Repository>
      */
-    public function findPending(): array
+    public function findLatest(int $limit): array
     {
         /** @var list<Repository> $repositories */
         $repositories = $this->createQueryBuilder('r')
-            ->where('r.analysed IS NULL')
-            ->orderBy('r.submitted', 'ASC')
+            ->orderBy('r.submitted', 'DESC')
+            // a batch submitted in one go shares its timestamp, so the order needs a second opinion
+            ->addOrderBy('r.id', 'DESC')
+            ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
 

--- a/templates/about.html.twig
+++ b/templates/about.html.twig
@@ -1,0 +1,78 @@
+{#
+ # What the report does not say by itself, on both screens rather than on a page of its own: what its
+ # numbers mean, how one gets into it, and what it is worth. The last part is the one that matters - a
+ # line going up reads as a verdict unless it says next to it that this is one metric among many, and
+ # that parts of the data are known to be off.
+ #
+ # The scale opens the block, across both columns: it is what every number of the report is read
+ # against, so it comes before the texts explaining where those numbers come from - and at half the
+ # width every band would set its risk in two lines.
+ #}
+<section class="about">
+    <div class="wrap about__inner">
+        <section class="about__section about__scale">
+            <h2 class="eyebrow">Complexity levels</h2>
+            {{ include('complexity_scale.html.twig') }}
+        </section>
+        <section class="about__section">
+            <h2 class="eyebrow">How the report is made</h2>
+            <p>
+                Anyone can submit a repository - github.com is the only source, and no
+                <code>composer.json</code> is needed. A submission is turned down when the
+                repository is unknown, a fork, empty, larger than 10&nbsp;GB, or less than 20%
+                PHP by the language breakdown github.com reports for it; everything else is
+                queued for a worker.
+            </p>
+            <p>
+                The worker clones it and checks out its release tags one after another. Only
+                major and minor releases are measured (<code>5.4</code>, <code>5.4.0</code>) -
+                patch releases and pre-releases (anything carrying a <code>-</code>) are skipped,
+                as are a handful of releases whose date git cannot tell straight. On every
+                checkout,
+                <a href="https://github.com/sebastianbergmann/phploc" target="_blank" rel="noreferrer">phploc</a>
+                reads every <code>.php</code> file of the working copy and leaves two numbers
+                behind: lines of code, and the average cyclomatic complexity of a class, dated by
+                the last commit that tag points at. The clone is deleted afterwards, the numbers
+                stay.
+            </p>
+            <p>
+                From then on the report keeps itself current: every night it refreshes stars and
+                asks github.com which releases are missing, so a new minor turns up in the chart
+                by itself - and a repository that did not release is not even cloned.
+            </p>
+        </section>
+        <section class="about__section">
+            <h2 class="eyebrow">About cyclomatic complexity</h2>
+            <p>
+                Cyclomatic complexity counts the paths through a piece of code: one, plus one for
+                every branch - <code>if</code>, <code>case</code>, <code>while</code>,
+                <code>for</code>, <code>catch</code>, <code>&amp;&amp;</code>, <code>||</code>.
+                Code without a single condition scores 1. What is charted here is the average
+                over all classes of a release, so it says how branchy the average class of a
+                library is - not how large it is, and not how good it is.
+            </p>
+            <p>
+                It is one metric, and worth what a metric is worth. It travels well as a rough
+                measure of how many paths a test suite has to cover, and badly as a verdict: a
+                clear class holding one big <code>match</code> outscores a tangle of indirection
+                nobody can follow, and pushing branches into polymorphism lowers the figure
+                without lowering the thinking. The shape of a line over the years says more than
+                any point on it.
+            </p>
+            <p>
+                The data has its glitches, too. Whatever sits in a repository at a tag is
+                measured, so committed dependencies, generated code and test suites count towards
+                the average. Libraries that were split, renamed or imported from another version
+                control system - Zend&nbsp;→&nbsp;Laminas, the early PHPUnit tags - carry dates
+                and jumps their git history cannot explain. And a gap in a line is a release
+                that was left out or could not be measured - not one that never happened.
+            </p>
+            <p class="about__links">
+                Further reading:
+                <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity" target="_blank" rel="noreferrer">Wikipedia</a>,
+                <a href="https://ieeexplore.ieee.org/document/1702388" target="_blank" rel="noreferrer">McCabe, A Complexity Measure (1976)</a>,
+                <a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication500-235.pdf" target="_blank" rel="noreferrer">NIST 500-235</a>.
+            </p>
+        </section>
+    </div>
+</section>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -46,79 +46,12 @@
         </header>
         {% block content %}{% endblock %}
         {#
-         # What the chart does not say by itself, on every page rather than on a page of its own: how a
-         # number gets into it, and what that number is worth. The second half is the one that matters -
-         # a line going up reads as a verdict unless it says next to it that this is one metric among
-         # many, and that parts of the data are known to be off. The scale closing the block is where
-         # the numbers themselves are read, and it stands under both columns because both lead to it.
+         # The credits, and nothing else: what the report is and what its numbers are worth is
+         # `about.html.twig`, which both screens place themselves - under the rankings on the start
+         # page, under the release analysis on the chart. Where it ends a screen it stands directly
+         # above this row and the two close one band, which is what the footer was before.
          #}
         <footer class="site-footer">
-            <div class="wrap site-footer__about">
-                <section class="site-footer__section">
-                    <h2 class="eyebrow">How the report is made</h2>
-                    <p>
-                        Anyone can submit a repository - github.com is the only source, and no
-                        <code>composer.json</code> is needed. A submission is turned down when the
-                        repository is unknown, a fork, empty, larger than 10&nbsp;GB, or less than 20%
-                        PHP by the language breakdown github.com reports for it; everything else is
-                        queued for a worker.
-                    </p>
-                    <p>
-                        The worker clones it and checks out its release tags one after another. Only
-                        major and minor releases are measured (<code>5.4</code>, <code>5.4.0</code>) -
-                        patch releases and pre-releases (anything carrying a <code>-</code>) are skipped,
-                        as are a handful of releases whose date git cannot tell straight. On every
-                        checkout,
-                        <a href="https://github.com/sebastianbergmann/phploc" target="_blank" rel="noreferrer">phploc</a>
-                        reads every <code>.php</code> file of the working copy and leaves two numbers
-                        behind: lines of code, and the average cyclomatic complexity of a class, dated by
-                        the last commit that tag points at. The clone is deleted afterwards, the numbers
-                        stay.
-                    </p>
-                    <p>
-                        From then on the report keeps itself current: every night it refreshes stars and
-                        asks github.com which releases are missing, so a new minor turns up in the chart
-                        by itself - and a repository that did not release is not even cloned.
-                    </p>
-                </section>
-                <section class="site-footer__section">
-                    <h2 class="eyebrow">About cyclomatic complexity</h2>
-                    <p>
-                        Cyclomatic complexity counts the paths through a piece of code: one, plus one for
-                        every branch - <code>if</code>, <code>case</code>, <code>while</code>,
-                        <code>for</code>, <code>catch</code>, <code>&amp;&amp;</code>, <code>||</code>.
-                        Code without a single condition scores 1. What is charted here is the average
-                        over all classes of a release, so it says how branchy the average class of a
-                        library is - not how large it is, and not how good it is.
-                    </p>
-                    <p>
-                        It is one metric, and worth what a metric is worth. It travels well as a rough
-                        measure of how many paths a test suite has to cover, and badly as a verdict: a
-                        clear class holding one big <code>match</code> outscores a tangle of indirection
-                        nobody can follow, and pushing branches into polymorphism lowers the figure
-                        without lowering the thinking. The shape of a line over the years says more than
-                        any point on it.
-                    </p>
-                    <p>
-                        The data has its glitches, too. Whatever sits in a repository at a tag is
-                        measured, so committed dependencies, generated code and test suites count towards
-                        the average. Libraries that were split, renamed or imported from another version
-                        control system - Zend&nbsp;→&nbsp;Laminas, the early PHPUnit tags - carry dates
-                        and jumps their git history cannot explain. And a gap in a line is a release
-                        that was left out or could not be measured - not one that never happened.
-                    </p>
-                    <p class="site-footer__links">
-                        Further reading:
-                        <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity" target="_blank" rel="noreferrer">Wikipedia</a>,
-                        <a href="https://ieeexplore.ieee.org/document/1702388" target="_blank" rel="noreferrer">McCabe, A Complexity Measure (1976)</a>,
-                        <a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication500-235.pdf" target="_blank" rel="noreferrer">NIST 500-235</a>.
-                    </p>
-                </section>
-                <section class="site-footer__section site-footer__scale">
-                    <h2 class="eyebrow">Complexity levels</h2>
-                    {{ include('complexity_scale.html.twig') }}
-                </section>
-            </div>
             <div class="site-footer__inner">
                 <span>Made with ♥ in Berlin by
                     <a href="https://x.com/chr_hertel" target="_blank" rel="noreferrer">@chr_hertel</a>

--- a/templates/chart.html.twig
+++ b/templates/chart.html.twig
@@ -193,4 +193,11 @@
             {% endif %}
         </div>
     </main>
+
+    {#
+     # What the chart does not say by itself closes this screen, below the release analysis. It stands
+     # outside the page rather than in it, because the credits follow it directly and the two are read
+     # as one band.
+     #}
+    {{ include('about.html.twig') }}
 {% endblock %}

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -265,35 +265,51 @@
                 {% else %}
                     <p class="empty-state">Nothing analysed yet - submit the first repository above.</p>
                 {% endif %}
-
-                {#
-                 # The GitHub accounts behind the repositories are a lens on the same list, not a place of
-                 # their own: every one of them opens the chart with what was submitted for it. Which is
-                 # why only accounts with more than one repository are listed - a single one is a link to
-                 # that repository under another name.
-                 #}
-                {% if organizations is not empty %}
-                    <p class="owner-line">
-                        <span class="owner-line__label">By owner</span>
-                        {% for organization in organizations %}
-                            <a href="{{ path('chart', {'repositories': organization.analysedRepositories|slice(0, chartLimit)|map(repository => repository.name)|join(',')}) }}">{{ organization.login }}</a>
-                        {% endfor %}
-                    </p>
-                {% endif %}
             </section>
+        </div>
 
-            {% if pending is not empty %}
+        {#
+         # What those numbers mean and where they come from, right after the first screen full of them
+         # and before the two quiet lists that close the page.
+         #}
+        {{ include('about.html.twig') }}
+
+        <div class="wrap page__body">
+            {#
+             # The GitHub accounts behind the repositories are a lens on the same list, not a place of
+             # their own: every one of them opens the chart with what was submitted for it. Which is
+             # why only accounts with more than one repository are listed - a single one is a link to
+             # that repository under another name.
+             #}
+            {% if organizations is not empty %}
+                <p class="owner-line">
+                    <span class="owner-line__label">By owner</span>
+                    {% for organization in organizations %}
+                        <a href="{{ path('chart', {'repositories': organization.analysedRepositories|slice(0, chartLimit)|map(repository => repository.name)|join(',')}) }}">{{ organization.login }}</a>
+                    {% endfor %}
+                </p>
+            {% endif %}
+
+            {#
+             # What came in last, whether it was measured yet or not - the rankings only show what has
+             # numbers, so this is the one place a repository shows up the day it was submitted. A chip
+             # says where its analysis stands as long as there is something to say about it.
+             #}
+            {% if latest is not empty %}
                 <section class="section">
                     <div class="section-header">
                         <div>
-                            <div class="eyebrow">Waiting for a worker</div>
-                            <h2>Queued for analysis</h2>
+                            <div class="eyebrow">Recently submitted</div>
+                            <h2>Latest additions</h2>
                         </div>
                     </div>
                     <div class="chip-row">
-                        {% for repository in pending %}
+                        {% for repository in latest %}
                             <a class="chip" href="{{ path('chart', {'repositories': repository.name}) }}">
                                 {{ repository.name }}
+                                {% if not repository.isAnalysed %}
+                                    <span class="chip__status">{{ repository.hasData ? 'analysing' : 'queued' }}</span>
+                                {% endif %}
                             </a>
                         {% endfor %}
                     </div>


### PR DESCRIPTION
Lifts the informational block out of the footer into `templates/about.html.twig`, levels first, and lets each screen place it: under the rankings on the start page, below the release analysis on the chart. The queue below it becomes "Latest additions" - the newest submissions, with a status on the chip while one is queued or being analysed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)