### PR TITLE
Open the chart on the ranking that is being read

### DIFF
--- a/assets/styles/_screens.scss
+++ b/assets/styles/_screens.scss
@@ -29,11 +29,26 @@
 }
 
 .ranking {
+    // caption and the link into the chart share one line: what the ranking sorts by on the left, the
+    // way to see it drawn on the right end of it
+    &__intro {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3) var(--space-5);
+        align-items: baseline;
+        justify-content: space-between;
+        margin: var(--space-4) 0 var(--space-5);
+    }
+
     &__caption {
         max-width: 70ch;
-        margin: var(--space-4) 0 var(--space-5);
+        margin: 0;
         font-size: var(--text-sm);
         color: var(--text-muted);
+    }
+
+    &__chart {
+        flex: 0 0 auto;
     }
 
     &[hidden] {

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -221,9 +221,6 @@
                         <div class="eyebrow">Rankings</div>
                         <h2 data-rankings-target="title">{{ rankings|first.ranking.title }}</h2>
                     </div>
-                    {% if hasData %}
-                        <a href="{{ path('chart') }}" class="btn btn--secondary">Open the chart</a>
-                    {% endif %}
                 </div>
 
                 {% if hasData %}
@@ -246,7 +243,20 @@
                         <div class="ranking" role="tabpanel" id="ranking-{{ entry.ranking.value }}"
                              aria-labelledby="tab-{{ entry.ranking.value }}"
                              data-rankings-target="panel" {{ not loop.first ? 'hidden' }}>
-                            <p class="ranking__caption">{{ entry.ranking.caption }}</p>
+                            {#
+                             # The chart opens on what is being read, so the link belongs to the ranking
+                             # rather than to the section above it: every panel carries its own, drawn
+                             # with its own top repositories, and only the visible one can be clicked.
+                             #}
+                            <div class="ranking__intro">
+                                <p class="ranking__caption">{{ entry.ranking.caption }}</p>
+                                {% if entry.repositories is not empty %}
+                                    <a class="btn btn--secondary ranking__chart"
+                                       href="{{ path('chart', {'repositories': entry.repositories|slice(0, chartLimit)|map(repository => repository.name)|join(',')}) }}">
+                                        Open the chart
+                                    </a>
+                                {% endif %}
+                            </div>
                             {#
                              # A ranking can come out empty although the report has data - nothing
                              # increased within the last twelve months is a result, not a broken page.


### PR DESCRIPTION
The "Open the chart" button of the rankings section always opened the most starred repositories, no matter which ranking was on screen.

It moves out of the section header and into the tab panel, at the right end of the caption. Every panel renders its own link, drawn with the top repositories of *that* ranking, in that order, up to `CHART_LIMIT` - so the button opens what is being read, and nothing has to be rewritten when a tab is picked, since only the visible panel can be clicked. A ranking that came out empty (nothing got more complex in the last 12 months) has nothing to draw and gets no link.

`.ranking__intro` is the caption and the link on one line - it wraps and the link drops under the caption on a phone.

Checked: `lint:twig`, `phpunit` (126 tests), prettier, `yarn build`, plus screenshots of the start page at 1440 and 420 wide and of a panel with a two-line caption.

Not touched: `CLAUDE.md`. The paragraph describing the start page is being rewritten in the working copy right now, so a doc edit here would only collide - the rule is written down in the template at the place it applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)