### PR TITLE
Streamline both screens into the editorial direction

### DIFF
--- a/assets/controllers/chart_controller.js
+++ b/assets/controllers/chart_controller.js
@@ -44,20 +44,9 @@ const METRICS = [
     { name: 'loc', key: 'loc', label: 'Lines of Code', short: count },
 ];
 const day = (value) => moment(value, 'YYYY-MM-DD').format('LL');
-const dot = () => element('span', 'release-head__dot', '·');
 
 // the star count of the rankings, shortened the way the `stars` twig filter shortens it
-function stars(total) {
-    const node = element('span', 'metric metric--star');
-
-    node.title = `${count(total)} stars on GitHub`;
-    node.append(
-        element('i', 'fas fa-star'),
-        element('span', null, total < 1000 ? String(total) : `${(total / 1000).toFixed(1).replace(/\.0$/, '')}k`),
-    );
-
-    return node;
-}
+const stars = (total) => (total < 1000 ? String(total) : `${(total / 1000).toFixed(1).replace(/\.0$/, '')}k`);
 
 // complexity going down is an improvement, going up is a regression
 const tone = (value) => (Math.abs(value) < 0.005 ? 'flat' : value < 0 ? 'good' : 'bad');
@@ -84,14 +73,22 @@ function trend(value, digits, label) {
  * long as the rule stays this small - four numbers and the band above the last of them.
  */
 const LEVELS = [
-    [10, 'simple'],
-    [20, 'moderate'],
-    [50, 'complex'],
+    [10, 'simple', '1–10'],
+    [20, 'moderate', '11–20'],
+    [50, 'complex', '21–50'],
 ];
-const level = (value) => LEVELS.find(([limit]) => value <= limit)?.[1] ?? 'untestable';
+const UNTESTABLE = ['untestable', '> 50'];
+const level = (value) => LEVELS.find(([limit]) => value <= limit)?.slice(1) ?? UNTESTABLE;
 
-// a measured complexity carrying the dot of its band, the way the cards of the start page carry it
-const complexity = (value) => element('span', `level level--${level(value)}`, decimal(value, 2));
+// a measured complexity carrying the dot of its band, the way the rows of the start page carry it
+const complexity = (value) => element('span', `level level--${level(value)[0]}`, decimal(value, 2));
+
+// where that complexity stands, said in words - the note under the figure it belongs to
+function band(value) {
+    const [name, range] = level(value);
+
+    return element('span', `level level--${name}`, `${name} · ${range}`);
+}
 
 function row(label, value, hint) {
     const node = element('div', 'analysis__row');
@@ -117,21 +114,43 @@ function group(title, rows) {
     return node;
 }
 
+/*
+ * One of the four figures a release comes down to, above the panel spelling it out. The note under a
+ * value is what makes it a reading rather than a number: where a complexity stands on the scale, which
+ * direction is the good one, what a size grew by, when the measuring started.
+ */
+function headline(label, value, note, tone) {
+    const node = element('div', 'headline-figures__cell');
+    const figure = element('div', `headline-figures__value${tone ? ` headline-figures__value--${tone}` : ''}`);
+
+    figure.append(value instanceof Node ? value : element('span', null, String(value)));
+    node.append(element('div', 'headline-figures__label', label), figure);
+
+    if (note) {
+        const caption = element('div', 'headline-figures__note');
+
+        caption.append(note instanceof Node ? note : element('span', null, String(note)));
+        node.append(caption);
+    }
+
+    return node;
+}
+
 export default class extends Controller {
     static targets = [
         'headline',
         'headlineLink',
         'canvas',
+        'count',
         'resetZoom',
         'select',
         'metric',
         'release',
         'releaseTabs',
         'releasePanel',
-        'releaseRepository',
-        'releaseName',
-        'releaseMeta',
+        'releaseLink',
         'releaseSelect',
+        'headlineFigures',
         'analysis',
         'raw',
         'rawTitle',
@@ -196,19 +215,13 @@ export default class extends Controller {
                     this.canvasTarget.style.cursor = elements.length > 0 ? 'pointer' : 'default';
                 },
                 plugins: {
-                    legend: {
-                        position: 'bottom',
-                        align: 'start',
-                        labels: {
-                            boxWidth: 8,
-                            boxHeight: 8,
-                            usePointStyle: true,
-                            pointStyle: 'rectRounded',
-                            color: TICK,
-                            font: { family: MONO, size: 11 },
-                            padding: 16,
-                        },
-                    },
+                    /*
+                     * The chips on the top edge of the panel are the legend: a line per chip, in the
+                     * colour it is drawn in, and they are there whether the chart holds five lines or
+                     * fifty. A second one under the chart would say the same thing twice and take the
+                     * height the chart is drawn in to do it.
+                     */
+                    legend: { display: false },
                     tooltip: {
                         backgroundColor: INK,
                         padding: 10,
@@ -358,15 +371,29 @@ export default class extends Controller {
             ...stroke(index),
         }));
 
-        // A legend of fifty entries is not a legend, it is the page - and it would take the height the
-        // chart is drawn in. The chips above the chart say the same thing in the same colours and stay
-        // one line per row, so past a palette they are the legend.
-        this.chart.options.plugins.legend.display = graphs.length <= SERIES_COLORS.length;
         this.chart.update();
         this.reflectZoom();
 
         this.renderHeadline(slugs);
+        this.renderCount(graphs);
         this.renderTabs(graphs);
+    }
+
+    /**
+     * What the chart is made of, on the strip under it - which is the one place the page counts what it
+     * drew rather than what it was opened with, since a line can be added and taken out without it.
+     */
+    renderCount(graphs) {
+        if (!this.hasCountTarget) {
+            return;
+        }
+
+        const releases = graphs.reduce((total, graph) => total + graph.tags.length, 0);
+
+        this.countTarget.textContent = [
+            `${count(graphs.length)} ${1 === graphs.length ? 'repository' : 'repositories'}`,
+            `${count(releases)} ${1 === releases ? 'release' : 'releases'}`,
+        ].join(' · ');
     }
 
     /**
@@ -500,6 +527,15 @@ export default class extends Controller {
         });
 
         this.release = graph;
+
+        // where the repository being read is read on github.com - the headline used to carry this link,
+        // and the release rail is where what is being read is now said
+        if (this.hasReleaseLinkTarget) {
+            this.releaseLinkTarget.href = graph.url;
+            this.releaseLinkTarget.title = graph.url.replace('https://', '');
+            this.releaseLinkTarget.setAttribute('aria-label', `${graph.name} on GitHub`);
+        }
+
         this.releaseSelectTarget.replaceChildren();
 
         graph.tags.forEach((tag, index) => {
@@ -525,64 +561,48 @@ export default class extends Controller {
         const first = tags[0];
 
         this.releaseSelectTarget.value = String(index);
-        this.releaseNameTarget.textContent = tag.name;
 
-        // where the release is read on github.com - the name of the repository is its address there
-        this.releaseRepositoryTarget.href = this.release.url;
-        this.releaseRepositoryTarget.title = this.release.url.replace('https://', '');
-        this.releaseRepositoryTarget.replaceChildren(
-            element('span', null, this.release.name),
-            element('i', 'fas fa-arrow-up-right-from-square'),
-        );
+        const lowest = tags.reduce((left, right) => (right.y < left.y ? right : left));
+        const highest = tags.reduce((left, right) => (right.y > left.y ? right : left));
+        const step = previous ? Math.round((tag.y - previous.y) * 100) / 100 : 0;
+        const grew = previous ? tag.loc - previous.loc : 0;
 
         /*
-         * The date a release carries is the day it was tagged, not the day the report measured it - the
-         * measurement happened whenever the repository was submitted or a nightly scan picked the release
-         * up, which is not what anyone reading a release is after.
+         * What the release comes down to, before the panel below spells it out. The date it carries is
+         * the day it was tagged, not the day the report measured it - the measurement happened whenever
+         * the repository was submitted or a nightly scan picked the release up, which is not what anyone
+         * reading a release is after.
          */
-        this.releaseMetaTarget.replaceChildren(element('span', null, `Released on ${day(tag.date)}`));
-
-        if (previous) {
-            this.releaseMetaTarget.append(
-                dot(),
-                element('span', null, 'Ø complexity'),
-                trend(Math.round((tag.y - previous.y) * 100) / 100, 2, `vs ${previous.name}`),
-            );
-        }
-
-        // what the repository behind the line is, next to the release being read from it
-        this.releaseMetaTarget.append(
-            dot(),
-            stars(this.release.stars),
-            dot(),
-            element('span', null, `First release ${day(first.date)}`),
+        this.headlineFiguresTarget.replaceChildren(
+            headline('Ø complexity', decimal(tag.y, 2), band(tag.y)),
+            previous
+                ? headline(`vs ${previous.name}`, signed(step, 2), 'down is an improvement', tone(step))
+                : headline('vs the release before', '–', 'nothing was measured before it'),
+            headline(
+                'Lines of code',
+                count(tag.loc),
+                previous ? `${signed(grew)} · ${share(grew, previous.loc) ?? '–'}` : 'as phploc counts them',
+            ),
+            headline('Analysed releases', count(tags.length), `first one ${day(first.date)}`),
         );
 
-        const complexities = tags.map((entry) => entry.y);
-
         const groups = [
-            group('Release', [
+            group('This release', [
                 row('Released', day(tag.date)),
-                row('Lines of code (LOC)', count(tag.loc)),
-                row('Ø cyclomatic complexity', complexity(tag.y)),
+                row('Lines of code', count(tag.loc)),
+                row('Ø complexity', complexity(tag.y)),
             ]),
-            previous
-                ? group(`Compared to ${previous.name}`, [
-                      row('Lines of code', signed(tag.loc - previous.loc), share(tag.loc - previous.loc, previous.loc)),
-                      row('Ø complexity', trend(Math.round((tag.y - previous.y) * 100) / 100, 2)),
-                  ])
-                : null,
             tag !== first
                 ? group(`Since ${first.name}`, [
                       row('Lines of code', signed(tag.loc - first.loc), share(tag.loc - first.loc, first.loc)),
                       row('Ø complexity', trend(Math.round((tag.y - first.y) * 100) / 100, 2)),
                   ])
                 : null,
-            // the first release is in the head, above every group - it says what the repository is
+            // where this release stands among the others, and what the repository behind them is
             group(`All ${tags.length} releases`, [
-                row('Analysed releases', count(tags.length)),
-                row('Lowest Ø complexity', complexity(Math.min(...complexities))),
-                row('Highest Ø complexity', complexity(Math.max(...complexities))),
+                row('Lowest Ø complexity', complexity(lowest.y), lowest.name),
+                row('Highest Ø complexity', complexity(highest.y), highest.name),
+                row('Stars on GitHub', stars(this.release.stars)),
             ]),
         ];
 

--- a/assets/controllers/disclosure_controller.js
+++ b/assets/controllers/disclosure_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from '@hotwired/stimulus';
+
+/*
+ * Something the page says in one line until somebody asks for the rest of it: the accounts behind the
+ * repositories at the end of the strip closing the start page, and the long version of what the
+ * numbers are worth under the block explaining them. Both are worth having and neither is worth the
+ * screenful it takes from what somebody came to read.
+ *
+ * Which way round it starts is the whole point of doing it here rather than in the template: the page
+ * is rendered with the panel open and the button not there, so a browser that never runs this reads
+ * everything the report has to say. Folding it away is the enhancement, so it is what the controller
+ * does on connect.
+ */
+export default class extends Controller {
+    static targets = ['toggle', 'panel'];
+
+    connect() {
+        this.panelTarget.hidden = true;
+        this.toggleTarget.hidden = false;
+        this.reflect();
+    }
+
+    toggle() {
+        this.panelTarget.hidden = !this.panelTarget.hidden;
+        this.reflect();
+    }
+
+    reflect() {
+        this.toggleTarget.setAttribute('aria-expanded', this.panelTarget.hidden ? 'false' : 'true');
+    }
+}

--- a/assets/controllers/rankings_controller.js
+++ b/assets/controllers/rankings_controller.js
@@ -3,9 +3,14 @@ import { Controller } from '@hotwired/stimulus';
 /*
  * The four orders the start page offers for its featured repositories. All of them are rendered, so
  * switching one on is a matter of hiding the others - no request, no reflow of the page below.
+ *
+ * The way into the chart belongs to the ranking rather than to the section above it: it draws what is
+ * being read, which is a different set of repositories per tab. There is one button for all four, so
+ * the tab carries where it goes and what it should say - and a ranking that came out empty carries
+ * neither, which is how the button knows to step aside.
  */
 export default class extends Controller {
-    static targets = ['tab', 'panel', 'title'];
+    static targets = ['tab', 'panel', 'title', 'chart'];
 
     select(event) {
         this.show(this.tabTargets.indexOf(event.currentTarget));
@@ -26,6 +31,23 @@ export default class extends Controller {
 
         if (this.hasTitleTarget) {
             this.titleTarget.textContent = this.tabTargets[index].dataset.title;
+        }
+
+        this.reflectChart(this.tabTargets[index]);
+    }
+
+    reflectChart(tab) {
+        if (!this.hasChartTarget) {
+            return;
+        }
+
+        const url = tab.dataset.chartUrl;
+
+        this.chartTarget.hidden = !url;
+
+        if (url) {
+            this.chartTarget.href = url;
+            this.chartTarget.textContent = tab.dataset.chartLabel;
         }
     }
 }

--- a/assets/controllers/search_controller.js
+++ b/assets/controllers/search_controller.js
@@ -21,11 +21,35 @@ export default class extends Controller {
         this.options = [];
         this.combobox = new Combobox(this.inputTarget, this.menuTarget, (index) => this.pick(index));
         this.requests = 0;
+        // the box has the key that reaches it drawn on it, so the key has to reach it
+        this.shortcut = (event) => this.focusOnSlash(event);
+        document.addEventListener('keydown', this.shortcut);
     }
 
     disconnect() {
         clearTimeout(this.timer);
         this.combobox.close();
+        document.removeEventListener('keydown', this.shortcut);
+    }
+
+    /**
+     * `/` puts the cursor in the box - unless it is being typed into something, which is every field on
+     * the page and anything made editable. A shortcut that swallows a character somebody meant to write
+     * is worse than no shortcut.
+     */
+    focusOnSlash(event) {
+        const active = document.activeElement;
+
+        if ('/' !== event.key || event.metaKey || event.ctrlKey || event.altKey) {
+            return;
+        }
+
+        if (active?.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(active?.tagName)) {
+            return;
+        }
+
+        event.preventDefault();
+        this.inputTarget.focus();
     }
 
     query() {

--- a/assets/controllers/trend_controller.js
+++ b/assets/controllers/trend_controller.js
@@ -1,11 +1,43 @@
 import { Controller } from '@hotwired/stimulus';
+import Chart from 'chart.js/auto';
+import 'chartjs-adapter-moment';
+import moment from 'moment';
 
 /*
- * The time frames the hero figure can be read in. Like the rankings below, all of them are rendered
- * with the request - picking one only swaps which is visible, nothing is fetched.
+ * The time frames the hero figure can be read in, and the line it took to get there. Like the rankings
+ * below, every window is rendered with the request - picking one swaps which figure is visible and
+ * redraws the line from what the page already carries, so nothing is fetched.
+ *
+ * The line is the same statement as the number above it: a point is the average complexity of the
+ * libraries that window compares, each of them standing at the last release it had by then. It starts
+ * on the `from` of the figure and ends on its `to`, which is why it is computed where the figure is
+ * (`TrendCalculator`) rather than assembled here.
  */
+
+// The hero is the one place the report draws on its brand ground, so the chart is inked for it: the
+// line is white and everything quiet a wash of it, where the tokens are ink on white.
+const LINE = '#ffffff';
+const FILL = 'rgba(255, 255, 255, 0.1)';
+const TICK = 'rgba(255, 255, 255, 0.6)';
+const GRID = 'rgba(255, 255, 255, 0.14)';
+const AXIS = 'rgba(255, 255, 255, 0.22)';
+const INK = '#101720';
+const MONO = 'IBM Plex Mono';
+const SANS = 'IBM Plex Sans';
+
 export default class extends Controller {
-    static targets = ['tab', 'panel'];
+    static targets = ['tab', 'panel', 'canvas'];
+    static values = { series: Array };
+
+    connect() {
+        this.window = 0;
+        this.draw();
+    }
+
+    disconnect() {
+        this.chart?.destroy();
+        this.chart = null;
+    }
 
     select(event) {
         const index = this.tabTargets.indexOf(event.currentTarget);
@@ -20,6 +52,79 @@ export default class extends Controller {
 
         this.panelTargets.forEach((panel, position) => {
             panel.hidden = position !== index;
+        });
+
+        this.window = index;
+        this.draw();
+    }
+
+    points() {
+        return this.seriesValue[this.window]?.points ?? [];
+    }
+
+    draw() {
+        if (!this.hasCanvasTarget) {
+            return;
+        }
+
+        if (this.chart) {
+            this.chart.data.datasets[0].data = this.points();
+            this.chart.update();
+
+            return;
+        }
+
+        this.chart = new Chart(this.canvasTarget, {
+            type: 'line',
+            data: {
+                datasets: [
+                    {
+                        label: 'Ø complexity',
+                        data: this.points(),
+                        borderColor: LINE,
+                        backgroundColor: FILL,
+                        fill: true,
+                        borderWidth: 2,
+                        pointRadius: 0,
+                        pointHoverRadius: 4,
+                        tension: 0.25,
+                    },
+                ],
+            },
+            options: {
+                maintainAspectRatio: false,
+                // one line, so what is being pointed at is a day of it rather than a point near the cursor
+                interaction: { mode: 'index', intersect: false },
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        backgroundColor: INK,
+                        padding: 10,
+                        cornerRadius: 6,
+                        displayColors: false,
+                        titleFont: { family: SANS, size: 12, weight: '600' },
+                        bodyFont: { family: MONO, size: 12 },
+                        callbacks: {
+                            title: (items) => moment(items[0].raw.x, 'YYYY-MM-DD').format('LL'),
+                            label: (item) => `Ø ${Number(item.raw.y).toFixed(2)}`,
+                        },
+                    },
+                },
+                scales: {
+                    x: {
+                        type: 'time',
+                        time: { parser: 'YYYY-MM-DD' },
+                        border: { color: AXIS },
+                        grid: { display: false },
+                        ticks: { color: TICK, font: { family: MONO, size: 11 }, maxTicksLimit: 8 },
+                    },
+                    y: {
+                        border: { display: false },
+                        grid: { color: GRID },
+                        ticks: { color: TICK, font: { family: MONO, size: 11 }, padding: 8, maxTicksLimit: 5 },
+                    },
+                },
+            },
         });
     }
 }

--- a/assets/styles/_base.scss
+++ b/assets/styles/_base.scss
@@ -100,8 +100,34 @@ canvas {
     padding: 0 var(--gutter);
 }
 
-// The top band of every page: the mark next to the wordmark on the left, a mono nav on the right,
-// one trailing control after it. A hairline is the only separation, there is no shadow.
+// What the report says to something that reads it rather than looks at it. Both screens open on a
+// figure rather than on a title, so the title they are still called by is carried here.
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
+
+// What a submission was answered with, directly under the box it was typed in.
+.flash-band {
+    padding: var(--space-4) 0;
+    background: var(--surface-band);
+    border-bottom: var(--border-width) solid var(--line);
+
+    .alert + .alert {
+        margin-top: var(--space-2);
+    }
+}
+
+// The top band of every page: the mark next to the wordmark on the left, the box the report is
+// searched and added to in the middle, a mono nav on the right. A hairline is the only separation,
+// there is no shadow.
 .site-header {
     background: var(--surface-band);
     border-bottom: var(--border-width) solid var(--line);
@@ -109,29 +135,29 @@ canvas {
     &__inner {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--space-4) var(--space-5);
+        gap: var(--space-4) var(--space-6);
         align-items: center;
         justify-content: space-between;
-        padding-top: var(--space-4);
-        padding-bottom: var(--space-4);
+        padding-top: 14px;
+        padding-bottom: 14px;
     }
 
     &__brand {
         display: flex;
+        flex: 0 0 auto;
         gap: var(--space-3);
         align-items: center;
         color: inherit;
     }
 
-    &__right {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--space-5);
-        align-items: center;
+    // the band holds three things now rather than two, so the lockup gives the box the width it needs
+    .logo__title {
+        font-size: 17px;
     }
 
     &__nav {
         display: flex;
+        flex: 0 0 auto;
         gap: var(--space-5);
         align-items: center;
         max-width: 100%;
@@ -161,25 +187,132 @@ canvas {
     }
 }
 
-// Start page opening: the wordmark and the size of the dataset on the brand ground, closed by the
-// mark the report is stamped with. The colour is the separation, so it carries no hairline.
+// The one box the report is navigated by, in the band above every screen. It is the combobox of the
+// design system with the field flattened into the band: a hairline box holding the key that reaches
+// it and what is typed into it, and the menu of _components.scss hanging under the whole thing.
+.site-search {
+    flex: 1 1 320px;
+    min-width: 0;
+    max-width: 420px;
+
+    &__control {
+        display: flex;
+        gap: var(--space-2);
+        align-items: center;
+        padding: 7px var(--space-3);
+        background: var(--surface-input);
+        border: var(--border-width) solid var(--input-border-color);
+        border-radius: var(--radius);
+        transition:
+            border-color var(--transition),
+            box-shadow var(--transition);
+
+        &:focus-within {
+            border-color: var(--brand);
+            box-shadow: var(--focus-ring);
+        }
+    }
+
+    // the key that puts the cursor here, drawn where it lands
+    &__key {
+        flex: 0 0 auto;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        line-height: 1;
+        color: var(--text-faint);
+    }
+
+    &__input {
+        flex: 1 1 auto;
+        min-width: 0;
+        padding: 0;
+        font-family: var(--font-sans);
+        font-size: var(--text-sm);
+        line-height: 1.4;
+        color: var(--text-heading);
+        background: none;
+        border: 0;
+        outline: none;
+
+        &::placeholder {
+            color: var(--text-faint);
+        }
+    }
+}
+
+// The start page opens on what the report has to say rather than on its own name: the figure, the
+// sentence it makes, the line it took to get there, and the size of the dataset under it. The mark and
+// the wordmark are in the band above, and saying them again is a screen introducing itself.
+//
+// The colour is the separation, so the band carries no hairline.
 .hero {
     padding: var(--hero-pad-top) 0 var(--hero-pad-bottom);
     background: var(--hero-bg);
     color: var(--hero-muted);
 
-    // stretched, not centred: the figure on the right is meant to stand as tall as the intro next
-    // to it, which it does by growing its own figure block rather than by being given a height.
-    &__inner {
+    // the reading on the left, the time frames it can be read in on the right, both sitting on the
+    // baseline the line below them starts from
+    &__top {
         display: flex;
         flex-wrap: wrap;
-        gap: var(--space-7);
-        align-items: stretch;
+        gap: var(--space-5) var(--space-7);
+        align-items: flex-end;
         justify-content: space-between;
     }
 
-    &__intro {
+    &__reading {
+        flex: 1 1 420px;
         min-width: 0;
+        max-width: 640px;
+    }
+
+    &__panel[hidden] {
+        display: none;
+    }
+
+    &__label {
+        font-family: var(--font-mono);
+        font-size: var(--text-eyebrow);
+        font-weight: var(--weight-medium);
+        letter-spacing: var(--tracking-eyebrow);
+        text-transform: uppercase;
+        color: var(--hero-faint);
+    }
+
+    &__numbers {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2) var(--space-5);
+        align-items: baseline;
+        margin-top: var(--space-3);
+    }
+
+    // The figure is the screen, so it is set at the size the wordmark used to be and then some. The
+    // trend tones of the design system are ink on white and would sink into the brand ground, so it
+    // borrows the lightened bars of the mark instead.
+    &__value {
+        font-size: 72px;
+        font-weight: var(--weight-semibold);
+        letter-spacing: var(--tracking-heading);
+        line-height: 1;
+        font-variant-numeric: tabular-nums;
+        color: var(--hero-fg);
+
+        &--good {
+            color: var(--mark-low);
+        }
+
+        &--bad {
+            color: var(--mark-high);
+        }
+    }
+
+    // the two ends the figure is the change between, which is what makes it a percentage of something
+    &__delta {
+        font-family: var(--font-mono);
+        font-size: var(--text-lg);
+        font-variant-numeric: tabular-nums;
+        color: var(--hero-fg);
     }
 
     &__subline {
@@ -201,99 +334,17 @@ canvas {
         }
     }
 
-    // the mark has no height of its own to stretch, so it stays centred against the intro
-    &__mark {
-        flex: 0 0 auto;
-        align-self: center;
-        width: clamp(104px, 16vw, 168px);
-        height: auto;
-    }
-
-    .logo__kicker {
-        color: var(--hero-faint);
-    }
-
-    .logo__title {
-        color: var(--hero-fg);
-    }
-}
-
-// The right hand side of the start hero: the whole dataset as one figure, over the time frames it can
-// be read in. The trend tones of the design system are ink on white and would sink into the brand
-// ground, so the number borrows the lightened bars of the mark instead.
-.hero-trend {
-    display: flex;
-    flex: 0 0 auto;
-    flex-direction: column;
-    width: clamp(260px, 26vw, 320px);
-    padding: var(--space-5);
-    background: rgba(255, 255, 255, 0.06);
-    border: var(--border-width) solid var(--hero-line);
-    border-radius: var(--radius-lg);
-
-    &__label {
-        font-family: var(--font-mono);
-        font-size: var(--text-eyebrow);
-        font-weight: var(--weight-medium);
-        letter-spacing: var(--tracking-eyebrow);
-        text-transform: uppercase;
-        color: var(--hero-faint);
-    }
-
-    // the one visible figure takes whatever height the intro gives the card, so the time frames
-    // stay on its bottom edge without being pinned there
-    &__figure {
-        flex: 1 1 auto;
-        margin-top: var(--space-4);
-
-        &[hidden] {
-            display: none;
-        }
-    }
-
-    &__value {
-        font-size: 38px;
-        font-weight: var(--weight-semibold);
-        letter-spacing: var(--tracking-heading);
-        line-height: var(--leading-heading);
-        font-variant-numeric: tabular-nums;
-        color: var(--hero-fg);
-
-        &--good {
-            color: var(--mark-low);
-        }
-
-        &--bad {
-            color: var(--mark-high);
-        }
-    }
-
-    &__caption {
-        margin-top: var(--space-2);
-        font-size: var(--text-sm);
-        color: var(--hero-muted);
-    }
-
-    &__since {
-        display: block;
-        margin-top: 2px;
-        font-family: var(--font-mono);
-        font-size: var(--text-xs);
-        color: var(--hero-faint);
-    }
-
-    // four equal columns, so the switch is one row at every width the card is given
+    // four equal columns, so the switch is one row at every width it is given
     &__windows {
         display: grid;
+        flex: 0 0 auto;
         grid-template-columns: repeat(4, minmax(0, 1fr));
         gap: var(--space-1);
-        margin-top: var(--space-5);
-        padding-top: var(--space-4);
-        border-top: var(--border-width) solid var(--hero-line);
+        width: 280px;
     }
 
     &__window {
-        padding: 4px 0;
+        padding: 5px 0;
         font-family: var(--font-mono);
         font-size: var(--text-xs);
         color: var(--hero-faint);
@@ -320,6 +371,65 @@ canvas {
             outline: none;
             box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.28);
         }
+    }
+
+    // the figure between its two ends - it owns its height, so the canvas has one to be drawn in
+    &__chart {
+        position: relative;
+        height: 180px;
+        margin-top: var(--space-5);
+    }
+
+    // How much of the report the figure above is an average of. Label and figure sit next to each
+    // other rather than stacked: this is the small print of the hero, not four headings.
+    &__stats {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3) var(--space-7);
+        margin: var(--space-5) 0 0;
+        padding-top: var(--space-4);
+        border-top: var(--border-width) solid var(--hero-line);
+    }
+
+    &__stat {
+        display: flex;
+        gap: 10px;
+        align-items: baseline;
+    }
+
+    &__stat-label {
+        font-family: var(--font-mono);
+        font-size: var(--text-eyebrow);
+        letter-spacing: var(--tracking-eyebrow);
+        text-transform: uppercase;
+        color: var(--hero-faint);
+    }
+
+    &__stat-value {
+        margin: 0;
+        font-size: var(--text-h3);
+        font-weight: var(--weight-semibold);
+        font-variant-numeric: tabular-nums;
+        color: var(--hero-fg);
+    }
+
+    // nothing measured yet is nothing to open on, so the mark stands where the figure would
+    &__inner--empty {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-5) var(--space-7);
+        align-items: center;
+    }
+
+    &__mark {
+        flex: 0 0 auto;
+        width: clamp(88px, 12vw, 120px);
+        height: auto;
+    }
+
+    &__inner--empty .hero__subline {
+        flex: 1 1 320px;
+        margin-top: 0;
     }
 }
 
@@ -352,15 +462,6 @@ canvas {
         letter-spacing: var(--tracking-heading);
         line-height: var(--leading-heading);
         color: var(--text-heading);
-    }
-
-    &--hero &__kicker {
-        margin-bottom: var(--space-2);
-        font-size: var(--text-eyebrow);
-    }
-
-    &--hero &__title {
-        font-size: var(--text-hero);
     }
 }
 
@@ -424,28 +525,41 @@ canvas {
     border-top: 0;
 }
 
-// Under 720px the lockup stacks above the nav row, which scrolls sideways instead of wrapping.
+// Under 900px the box drops under the lockup and takes the row it is on, rather than being squeezed
+// between two things that cannot give.
+@media (max-width: 900px) {
+    .site-search {
+        order: 3;
+        flex-basis: 100%;
+        max-width: none;
+    }
+}
+
+// Under 720px the three of them stack, and the nav scrolls sideways instead of wrapping.
 @media (max-width: 720px) {
     .site-header__inner {
         flex-direction: column;
-        align-items: flex-start;
+        align-items: stretch;
         gap: var(--space-3);
+    }
+
+    .site-search {
+        order: 0;
     }
 }
 
 @media (max-width: 640px) {
     :root {
-        --text-hero: 38px;
-        --hero-pad-top: var(--space-8);
+        --hero-pad-top: var(--space-7);
     }
 
-    // Too small to read as the mark, and the header carries it two rows further up anyway.
-    .hero__mark {
-        display: none;
+    // The figure is the screen, so it keeps leading it - at the size a phone has room for.
+    .hero__value {
+        font-size: 48px;
     }
 
-    // The figure is content, so it stays - it drops under the intro and takes the full width there.
-    .hero-trend {
+    // The time frames are content too: they drop under the figure and take the width there.
+    .hero__windows {
         width: 100%;
     }
 }

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -55,6 +55,11 @@
         cursor: default;
         pointer-events: none;
     }
+
+    // a ranking that came out empty has nothing to draw, so the button steps aside rather than fades
+    &[hidden] {
+        display: none;
+    }
 }
 
 // --- TextInput --------------------------------------------------------------------------------
@@ -204,175 +209,223 @@
     }
 }
 
-// --- RepositoryCard ---------------------------------------------------------------------------
-// One analysed repository: vendor line, name, description, then a metrics row.
-.repo-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: var(--space-5);
-}
+// --- RankingTable -----------------------------------------------------------------------------
+// A ranking as what it is: an order. Nine repositories used to be nine cards, which reads as nine
+// things rather than as first to ninth - a rank, a name, three measured columns and the way out to
+// github.com, all of them lining up down the table so a column can be read as a column.
+//
+// The three measured ones follow the tab (`Ranking::columns()`), so whatever the ranking sorts by is
+// the one right of the name.
+.ranking-table {
+    --ranking-columns: 44px minmax(0, 1fr) 96px 96px 96px 28px;
 
-.repo-card {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
+    margin-top: var(--space-5);
     background: var(--surface-card);
     border: var(--border-width) solid var(--card-border-color);
     border-radius: var(--radius-lg);
-    transition:
-        border-color var(--transition),
-        box-shadow var(--transition);
+    overflow: hidden;
 
-    &:hover {
-        border-color: var(--line-strong);
-        box-shadow: var(--shadow-xs);
-    }
-
-    &__body {
-        flex: 1 1 auto;
-        padding: var(--card-pad);
+    &__head,
+    &__row {
+        display: grid;
+        grid-template-columns: var(--ranking-columns);
+        gap: var(--space-4);
+        align-items: center;
     }
 
     &__head {
-        display: flex;
-        align-items: baseline;
-        gap: var(--space-3);
-        margin-bottom: var(--space-2);
+        padding: 10px var(--space-5);
         font-family: var(--font-mono);
-        font-size: var(--text-xs);
-        font-variant-numeric: tabular-nums;
-        white-space: nowrap;
-    }
-
-    &__rank {
-        color: var(--text-faint);
-    }
-
-    &__vendor {
-        overflow: hidden;
-        text-overflow: ellipsis;
+        font-size: 11px;
         letter-spacing: var(--tracking-eyebrow);
         text-transform: uppercase;
         color: var(--text-muted);
+        background: var(--surface-muted);
+        border-bottom: var(--border-width) solid var(--line);
     }
 
-    &__title {
-        margin-bottom: var(--space-2);
-        font-size: var(--text-h5);
-        font-weight: var(--weight-semibold);
-        letter-spacing: var(--tracking-tight);
+    &__number {
+        text-align: right;
+    }
 
-        a {
-            color: var(--text-heading);
+    &__row {
+        padding: 14px var(--space-5);
+        border-bottom: var(--border-width) solid var(--line);
+        transition: background-color var(--transition);
+
+        &:last-child {
+            border-bottom: 0;
+        }
+
+        &:hover {
+            background: var(--surface-muted);
         }
     }
 
-    &:hover &__title a {
+    &__rank {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-variant-numeric: tabular-nums;
+        color: var(--text-faint);
+    }
+
+    &__repository {
+        min-width: 0;
+    }
+
+    &__name {
+        font-family: var(--font-mono);
+        font-size: 14px;
+        font-weight: var(--weight-medium);
+        color: var(--text-heading);
+    }
+
+    &__row:hover &__name {
         text-decoration: underline;
         text-underline-offset: 3px;
     }
 
-    &__text {
+    // one line: a description is what a repository says about itself, not what the report says
+    &__description {
+        display: block;
+        overflow: hidden;
         font-size: var(--text-sm);
-        line-height: 1.55;
+        line-height: 1.5;
         color: var(--text-muted);
-        text-wrap: pretty;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
-    &__meta {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: var(--space-2) var(--space-4);
-        padding: var(--space-3) var(--card-pad);
-        border-top: var(--border-width) solid var(--line);
+    &__cell {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+        white-space: nowrap;
+        color: var(--text-muted);
+
+        .fas {
+            margin-right: 6px;
+            font-size: 11px;
+            color: var(--accent-star);
+        }
+
+        // the measurement the report is about is the one that carries the ink of a heading
+        &--strong {
+            color: var(--text-heading);
+        }
+
+        &--good {
+            color: var(--trend-improving);
+        }
+
+        &--bad {
+            color: var(--trend-regressing);
+        }
     }
 
     &__github {
-        margin-left: auto;
         font-size: 14px;
+        text-align: right;
         color: var(--text-faint);
+
+        &:hover {
+            color: var(--text-heading);
+        }
     }
 }
 
-.metric {
-    font-family: var(--font-mono);
-    font-size: var(--text-xs);
-    font-variant-numeric: tabular-nums;
-    color: var(--text-muted);
-    white-space: nowrap;
+// Under a laptop the three measured columns are what has to give: the two the ranking is not about
+// drop, the one it sorts by stays, and the name keeps the width it needs to stay on one line.
+//
+// A row is rank, name, three figures, github - so the two that go are the fourth and the fifth of it.
+@media (max-width: 900px) {
+    .ranking-table {
+        --ranking-columns: 36px minmax(0, 1fr) 88px 28px;
 
-    &__label,
-    .fas,
-    .fab {
-        margin-right: 6px;
-        font-size: 11px;
-        color: var(--text-faint);
-    }
-
-    &--good {
-        color: var(--trend-improving);
-    }
-
-    &--bad {
-        color: var(--trend-regressing);
-    }
-
-    &--star .fas {
-        color: var(--accent-star);
+        &__head > :nth-child(4),
+        &__head > :nth-child(5),
+        &__row > :nth-child(4),
+        &__row > :nth-child(5) {
+            display: none;
+        }
     }
 }
 
-// --- StatsLine --------------------------------------------------------------------------------
-// Dataset size as four labelled figures on one hairline-separated row.
-.stats {
+@media (max-width: 560px) {
+    .ranking-table {
+        &__head,
+        &__row {
+            gap: var(--space-3);
+            padding-inline: var(--space-4);
+        }
+
+        &__description {
+            display: none;
+        }
+    }
+}
+
+// --- HeadlineFigures --------------------------------------------------------------------------
+// What the release being read comes down to, above the panel spelling it out: four figures in one
+// hairline grid, each of them with the note that makes it a reading rather than a number.
+.headline-figures {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: var(--space-5);
-    margin: 0;
-    padding: var(--space-5) 0;
-    border-top: var(--border-width) solid var(--line);
+    gap: var(--border-width);
+    margin-top: var(--space-5);
+    background: var(--line);
+    border: var(--border-width) solid var(--line);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+
+    &__cell {
+        padding: var(--space-5);
+        background: var(--surface-card);
+    }
 
     &__label {
         font-family: var(--font-mono);
-        font-size: var(--text-xs);
+        font-size: 11px;
         letter-spacing: var(--tracking-eyebrow);
         text-transform: uppercase;
         color: var(--text-muted);
     }
 
     &__value {
-        margin: var(--space-2) 0 0;
-        font-size: var(--text-h2);
+        margin-top: 10px;
+        font-size: 28px;
         font-weight: var(--weight-semibold);
         font-variant-numeric: tabular-nums;
-        letter-spacing: var(--tracking-tight);
+        letter-spacing: var(--tracking-heading);
         color: var(--text-heading);
+
+        &--good {
+            color: var(--trend-improving);
+        }
+
+        &--bad {
+            color: var(--trend-regressing);
+        }
     }
 
-    // In the hero the same row is read on the brand ground, and only three of the four figures are
-    // shown - the vendors are one section of the page below.
-    &--hero {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        max-width: 34rem;
-        margin-top: var(--space-5);
-        padding: var(--space-4) 0 0;
-        border-top-color: var(--hero-line);
-    }
-
-    &--hero &__label {
-        color: var(--hero-faint);
-    }
-
-    &--hero &__value {
-        color: var(--hero-fg);
+    &__note {
+        margin-top: var(--space-1);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--text-faint);
     }
 }
 
-@media (max-width: 720px) {
-    // Two columns is as far as the labels go before they collide - the hero row wraps with them.
-    .stats {
+@media (max-width: 900px) {
+    .headline-figures {
         grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 480px) {
+    .headline-figures {
+        grid-template-columns: minmax(0, 1fr);
     }
 }
 
@@ -408,10 +461,12 @@
     }
 
     // where a repository stands is a state, not a measurement - set the way every other label of the
-    // report is set, so it is not read as a version
+    // report is set, so it is not read as a version, and on the brand rather than on ink, so a strip
+    // of versions is scanned past it rather than through it
     &__value--state {
         letter-spacing: var(--tracking-eyebrow);
         text-transform: uppercase;
+        background: var(--brand);
     }
 }
 
@@ -422,6 +477,10 @@ a.pill:hover .pill__name {
 
 a.pill:hover .pill__value {
     background: var(--ink-900);
+}
+
+a.pill:hover .pill__value--state {
+    background: var(--brand-strong);
 }
 
 .pill-row {
@@ -697,31 +756,25 @@ a.pill:hover .pill__value {
 
 .chart-canvas {
     position: relative;
-    height: 420px;
+    height: 440px;
 }
 
-// What the chart draws, above the panel it draws it in - the two numbers a release is measured in,
-// side by side rather than in a select, because there are two of them and both are worth naming.
+// What the chart draws, on the top edge of the panel it draws it in - the two numbers a release is
+// measured in, side by side rather than in a select, because there are two of them and both are worth
+// naming.
 //
 // It is a segmented control rather than two quiet words: the sunken track is what says that both of
 // them are options and one of them is taken, which a label on its own cannot say. So the track carries
 // the affordance and the raised half carries the state, the way a switch is read everywhere else.
 .chart-metrics {
     display: flex;
+    flex: 0 0 auto;
     gap: 2px;
-    // the switch stands over the right edge of the chart, where it is out of the way of a headline
     width: fit-content;
     padding: 2px;
-    margin: var(--space-6) 0 0 auto;
     background: var(--surface-muted);
     border: var(--border-width) solid var(--line);
     border-radius: var(--radius);
-}
-
-// the switch belongs to the chart it draws, so the panel follows it at a hair rather than at the
-// distance it keeps from whatever stands above the whole block
-.chart-metrics + .chart-panel {
-    margin-top: var(--space-2);
 }
 
 .metric-switch {
@@ -843,8 +896,8 @@ a.pill:hover .pill__value {
 // The measurement of one release, grouped the way the report reads it.
 .analysis {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: var(--space-6) var(--space-7);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: var(--space-6);
 
     &__title {
         padding-bottom: var(--space-3);
@@ -888,70 +941,6 @@ a.pill:hover .pill__value {
         font-family: var(--font-mono);
         font-size: var(--text-xs);
         color: var(--text-faint);
-    }
-}
-
-.release-head {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-4);
-    align-items: flex-end;
-    justify-content: space-between;
-    margin-bottom: var(--space-5);
-
-    h2 {
-        display: flex;
-        align-items: baseline;
-        gap: var(--space-3);
-        margin-top: var(--space-2);
-        font-size: var(--text-h3);
-    }
-
-    // the repository is a link to github.com, so it carries the same arrow the chart headline does
-    &__name {
-        font-family: var(--font-mono);
-        font-weight: var(--weight-medium);
-        color: inherit;
-        text-decoration: none;
-
-        .fas {
-            margin-left: var(--space-2);
-            font-size: 13px;
-            color: var(--text-faint);
-        }
-
-        // only the name is underlined on hover, the arrow behind it is not part of it
-        &:hover span {
-            text-decoration: underline;
-        }
-    }
-
-    &__meta {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: baseline;
-        gap: var(--space-3);
-        margin-top: var(--space-3);
-        font-size: var(--text-sm);
-        color: var(--text-muted);
-    }
-
-    &__dot {
-        color: var(--text-faint);
-    }
-
-    // what can be done with the release being read, next to the box that picks it - the two are the
-    // same control geometry, so they sit on one line without either of them being made to fit
-    &__actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--space-3);
-        align-items: center;
-
-        .fas {
-            font-size: 11px;
-            color: var(--text-faint);
-        }
     }
 }
 
@@ -1172,19 +1161,69 @@ a.pill:hover .pill__value {
     border-bottom: var(--border-width) solid var(--line);
 
     &__inner {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: var(--space-7);
         padding-top: var(--space-7);
         padding-bottom: var(--space-6);
     }
 
-    &__scale {
+    &__label {
+        display: block;
+        margin-bottom: var(--space-3);
+    }
+
+    &__columns {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--space-6) var(--space-7);
+        margin-top: var(--space-6);
+    }
+
+    // every caveat spelled out, under the two columns saying the short version of them
+    &__long {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
         grid-column: 1 / -1;
+        gap: var(--space-6) var(--space-7);
+        padding-top: var(--space-5);
+        border-top: var(--border-width) solid var(--line);
+
+        &[hidden] {
+            display: none;
+        }
+    }
+
+    // the sentence that opens it, set like the quiet links of this block because that is what it is
+    &__reveal {
+        margin: 0;
+    }
+
+    &__more {
+        padding: 0;
+        font-family: var(--font-sans);
+        font-size: var(--text-sm);
+        color: var(--text-muted);
+        background: none;
+        border: 0;
+        border-bottom: 1px solid var(--line-strong);
+        cursor: pointer;
+        transition: color var(--transition);
+
+        &:hover {
+            color: var(--text-heading);
+        }
+
+        &:focus-visible {
+            outline: none;
+            box-shadow: var(--focus-ring);
+        }
+
+        &[hidden] {
+            display: none;
+        }
     }
 
     &__section {
-        h2 {
+        h2,
+        h3 {
             margin-bottom: var(--space-3);
         }
 
@@ -1219,7 +1258,8 @@ a.pill:hover .pill__value {
 
 // the two explaining columns become two blocks, read one after the other
 @media (max-width: 720px) {
-    .about__inner {
+    .about__columns,
+    .about__long {
         grid-template-columns: minmax(0, 1fr);
         gap: var(--space-6);
     }

--- a/assets/styles/_screens.scss
+++ b/assets/styles/_screens.scss
@@ -1,54 +1,17 @@
-// Layout of the two screens the product has - StartScreen.jsx and ChartScreen.jsx in the design
-// project. Everything they are built from lives in _components.scss.
+// Layout of the two screens the product has. Everything they are built from lives in
+// _components.scss; what is here is where those pieces stand.
 
 .page__body {
     padding-top: var(--space-8);
 }
 
 // --- Start ------------------------------------------------------------------------------------
-// The input spans the band, announced by the label above it and explained by the hint underneath.
-.submit-band {
-    &__label {
-        margin-bottom: var(--space-3);
-    }
-
-    &__hint {
-        margin-top: var(--space-3);
-        font-size: var(--text-sm);
-        color: var(--text-muted);
-    }
-
-    .alert {
-        margin-top: var(--space-3);
-    }
-}
-
-.submit-form {
-    display: flex;
-    gap: var(--space-2);
-}
-
 .ranking {
-    // caption and the link into the chart share one line: what the ranking sorts by on the left, the
-    // way to see it drawn on the right end of it
-    &__intro {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--space-3) var(--space-5);
-        align-items: baseline;
-        justify-content: space-between;
-        margin: var(--space-4) 0 var(--space-5);
-    }
-
     &__caption {
-        max-width: 70ch;
-        margin: 0;
+        max-width: 92ch;
+        margin: var(--space-3) 0 0;
         font-size: var(--text-sm);
         color: var(--text-muted);
-    }
-
-    &__chart {
-        flex: 0 0 auto;
     }
 
     &[hidden] {
@@ -61,53 +24,79 @@
     color: var(--text-muted);
 }
 
-// The GitHub accounts behind the repositories: a row of pills under their label, not a section of
-// its own - which is why it carries no rule above it either, the band it follows is separation
-// enough. The pills themselves are `.pill` in _components.scss, the same ones the lists below use.
-.vendors {
-    &__label {
-        margin-bottom: var(--space-3);
-    }
-}
-
-// The two ends of what came in last, side by side: repositories somebody submitted, releases a worker
-// measured. On a phone one column, the submissions first.
-.latest {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--space-6);
+// What came in last, on one line: a pill per repository, and the accounts behind them folded away at
+// the end of it. It closes the page, so it is a strip rather than a section - two lists under two
+// headings were more page than what they say is worth.
+.just-in {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3) var(--space-6);
+    align-items: baseline;
+    margin-top: var(--space-7);
+    padding: var(--space-4) var(--space-5);
+    background: var(--surface-card);
+    border: var(--border-width) solid var(--card-border-color);
+    border-radius: var(--radius-lg);
 
     &__label {
-        margin-bottom: var(--space-3);
+        flex: 0 0 auto;
+        font-size: 11px;
     }
 
-    @media (max-width: 720px) {
-        grid-template-columns: minmax(0, 1fr);
+    // the way into the vendors sits on the far end of the strip, quiet like everything else on it
+    &__more {
+        flex: 0 0 auto;
+        margin-left: auto;
+        padding: 0;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--text-muted);
+        background: none;
+        border: 0;
+        border-bottom: 1px solid var(--line-strong);
+        cursor: pointer;
+        transition: color var(--transition);
+
+        &::after {
+            content: ' →';
+        }
+
+        &[aria-expanded='true']::after {
+            content: ' ↑';
+        }
+
+        &:hover {
+            color: var(--text-heading);
+        }
+
+        &:focus-visible {
+            outline: none;
+            box-shadow: var(--focus-ring);
+        }
+
+        &[hidden] {
+            display: none;
+        }
+    }
+
+    // opened, it is a row of its own under the strip rather than a column squeezed against its end
+    &__vendors {
+        flex: 1 0 100%;
+        margin-top: var(--space-1);
+        padding-top: var(--space-4);
+        border-top: var(--border-width) solid var(--line);
+
+        &[hidden] {
+            display: none;
+        }
     }
 }
 
 // --- Chart ------------------------------------------------------------------------------------
-.chart-title {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    margin-top: var(--space-2);
-    font-size: var(--text-h2);
-
-    &__link {
-        font-size: 13px;
-        color: var(--text-faint);
-    }
-}
-
 .chart-lead {
     margin-top: var(--space-3);
     font-size: var(--text-sm);
     color: var(--text-muted);
-}
-
-.chart-panel {
-    margin-top: var(--space-6);
 }
 
 // One alert per repository the chart is still waiting for.
@@ -117,24 +106,134 @@
     margin-top: var(--space-6);
 }
 
-// as wide as the chart below it - the chips in it are the series it is drawn from, in the same order
-.repository-picker {
-    margin-top: var(--space-5);
+// The chart and everything about it in one panel: what it is drawn from on the top edge, what it is
+// drawn as next to that, the chart itself, and what it is made of on the bottom edge. The panel pads
+// the chart and nothing else, so the two edges run to its full width.
+.chart-panel {
+    padding: 0;
 
-    &__hint {
-        margin-top: var(--space-3);
-        font-size: var(--text-sm);
+    &__head,
+    &__foot {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-4);
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    &__head {
+        padding: var(--space-4) var(--space-5);
+        border-bottom: var(--border-width) solid var(--line);
+    }
+
+    // the chips are the legend of the chart, so the box holding them is as wide as they need
+    &__picker {
+        flex: 1 1 320px;
+    }
+
+    &__foot {
+        padding: 10px var(--space-5);
+        font-size: var(--text-xs);
         color: var(--text-muted);
+        border-top: var(--border-width) solid var(--line);
+    }
+
+    &__count {
+        font-family: var(--font-mono);
+        font-variant-numeric: tabular-nums;
+    }
+
+    .chart-canvas {
+        margin: var(--space-5);
     }
 }
 
-// The release analysis reads eyebrow → the tabs that pick a line → the release being read. With a
-// single line there is nothing to pick, and the head moves up under the eyebrow.
-.tabs--series {
-    margin-top: var(--space-3);
+// In the panel head the field is not a field: the chips are what is in the chart, and what is left of
+// the box is the one dashed slot another line is added in. So the border moves off the control and
+// onto that slot, which is the only part of it that is an invitation.
+.chart-panel__picker.combobox {
+    .combobox__control {
+        padding: 0;
+        background: none;
+        border: 0;
+        border-radius: 0;
 
-    &:not([hidden]) + .release-head {
-        margin-top: var(--space-5);
+        &:focus-within {
+            box-shadow: none;
+        }
+    }
+
+    .combobox__input {
+        flex: 0 1 12rem;
+        padding: 4px var(--space-2);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        border: var(--border-width) dashed var(--line-strong);
+        border-radius: var(--radius-sm);
+        transition:
+            border-color var(--transition),
+            box-shadow var(--transition);
+
+        &:focus {
+            border-style: solid;
+            border-color: var(--brand);
+            box-shadow: var(--focus-ring);
+        }
+    }
+}
+
+// The release analysis reads: the lines that can be read, the release picked out of one of them, and
+// then the release. The tabs and what picks a release share the rail, because both of them choose
+// what the figures below show.
+.release {
+    &__rail {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3) var(--space-5);
+        align-items: flex-end;
+        justify-content: space-between;
+        border-bottom: var(--border-width) solid var(--line);
+    }
+
+    &__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        align-items: center;
+        padding-bottom: var(--space-2);
+
+        .fas {
+            font-size: 11px;
+            color: var(--text-faint);
+        }
+    }
+
+    // where the repository being read is read on github.com
+    &__link {
+        font-size: 13px;
+        color: var(--text-faint);
+
+        &:hover {
+            color: var(--text-heading);
+        }
+    }
+}
+
+// The tabs sit on the rail rather than under a heading - with a single line there is nothing to pick
+// and they are not rendered at all, which is what the rail is left holding.
+//
+// A chart of fifty lines is fifty tabs, and they scroll rather than wrap: the rail is one row, and the
+// controls sharing it belong on its right end whatever is to the left of them.
+.tabs--series {
+    flex: 1 1 auto;
+    gap: var(--space-4);
+    min-width: 0;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    border-bottom: 0;
+
+    .tab {
+        flex: 0 0 auto;
     }
 }
 

--- a/assets/styles/_tokens.scss
+++ b/assets/styles/_tokens.scss
@@ -116,8 +116,10 @@
     --space-8: 64px;
     --space-9: 96px;
 
-    --hero-pad-top: var(--space-9);
-    --hero-pad-bottom: var(--space-8);
+    // The hero used to be an introduction and is a reading now - it opens on the figure rather than on
+    // the wordmark, so it stands closer to the band above it than a title would have.
+    --hero-pad-top: 56px;
+    --hero-pad-bottom: 40px;
 
     --gutter: var(--space-6);
     --container: 1200px;

--- a/src/ComplexityReport/Activity.php
+++ b/src/ComplexityReport/Activity.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport;
+
+use App\Entity\Repository;
+use App\Entity\Tag;
+
+/**
+ * One entry of the strip closing the start page: a repository and the last thing that happened to it.
+ *
+ * The page used to close on two lists - the repositories somebody submitted, and the releases a worker
+ * measured. They are the two ends of the same work, and read next to each other they are one line: what
+ * came in. So they are the same pill here, and what differs is only what its dark half says - a state
+ * while a repository is waiting for a worker, the version once one measured something.
+ *
+ * Waiting repositories come first and are never crowded out. A queued repository is the one thing on
+ * this strip somebody is still owed an answer about; a release that arrived is done.
+ */
+final readonly class Activity
+{
+    private function __construct(
+        /** The repository, `vendor/repository` - which is also what the pill links to its chart by. */
+        public string $repository,
+        /** What is said about it: a state while it waits, the version of the release otherwise. */
+        public string $value,
+        /** Whether that value is a state rather than a version - a state is set like every other label. */
+        public bool $state,
+        public string $title,
+    ) {
+    }
+
+    /**
+     * The strip: everything still waiting for a worker, then the newest releases filling what is left.
+     *
+     * A repository is named once. A queued repository whose first releases just arrived would otherwise
+     * stand on the strip twice, saying two different things about itself.
+     *
+     * @param list<Repository> $submitted most recently submitted first
+     * @param list<Tag>        $released  most recently measured first
+     *
+     * @return list<self>
+     */
+    public static function feed(array $submitted, array $released, int $limit): array
+    {
+        $feed = [];
+        $named = [];
+
+        foreach ($submitted as $repository) {
+            // a repository that is measured has nothing outstanding - its releases speak for it below
+            if ($repository->isAnalysed()) {
+                continue;
+            }
+
+            $feed[] = self::waiting($repository);
+            $named[$repository->getName()] = true;
+        }
+
+        foreach ($released as $tag) {
+            $name = $tag->getRepository()->getName();
+
+            if (\count($feed) >= $limit) {
+                break;
+            }
+
+            if (isset($named[$name])) {
+                continue;
+            }
+
+            $feed[] = self::released($tag);
+            $named[$name] = true;
+        }
+
+        return \array_slice($feed, 0, $limit);
+    }
+
+    /**
+     * A repository between being submitted and being in the report: queued while nothing was measured
+     * yet, being analysed once the first releases came in.
+     */
+    private static function waiting(Repository $repository): self
+    {
+        return $repository->hasData()
+            ? new self(
+                $repository->getName(),
+                'analysing',
+                true,
+                sprintf('%s is being measured right now - %d releases so far', $repository->getName(), $repository->getReleaseCount()),
+            )
+            : new self(
+                $repository->getName(),
+                'queued',
+                true,
+                sprintf('%s is waiting for a worker', $repository->getName()),
+            );
+    }
+
+    private static function released(Tag $tag): self
+    {
+        return new self(
+            $tag->getRepository()->getName(),
+            $tag->getName(),
+            false,
+            sprintf(
+                '%s %s, tagged %s',
+                $tag->getRepository()->getName(),
+                $tag->getName(),
+                $tag->getCreated()->format('F j, Y'),
+            ),
+        );
+    }
+}

--- a/src/ComplexityReport/ChartSelection.php
+++ b/src/ComplexityReport/ChartSelection.php
@@ -57,6 +57,19 @@ final readonly class ChartSelection
     }
 
     /**
+     * How many releases the chart is drawn from, across every line in it - what the strip under the
+     * chart says it is made of, next to how many lines that is. The browser recounts it whenever a line
+     * is added or taken out, so this is only what the page opens on.
+     */
+    public function getReleaseCount(): int
+    {
+        return array_sum(array_map(
+            static fn (Repository $repository) => $repository->getReleaseCount(),
+            $this->getSeries(),
+        ));
+    }
+
+    /**
      * Everything that can be picked, what is drawn first: the position of an option is the colour of its
      * line, so the repositories the page was opened with keep the order they were asked for.
      *

--- a/src/ComplexityReport/Ranking.php
+++ b/src/ComplexityReport/Ranking.php
@@ -67,6 +67,46 @@ enum Ranking: string
     }
 
     /**
+     * The three measured columns of the ranking table, in the order this ranking prints them - whatever
+     * it sorts by comes first, so the order the rows are in is readable off the rows themselves.
+     *
+     * `key` is which figure a cell holds, `label` what its header says. A header cell is one column of a
+     * dense row and has room for a word, which is why the short ones are spelled out in
+     * {@see self::legend()} under the table rather than in the heading itself.
+     *
+     * @return list<array{key: string, label: string}>
+     */
+    public function columns(): array
+    {
+        $stars = ['key' => 'stars', 'label' => 'Stars'];
+        $complexity = ['key' => 'complexity', 'label' => 'Ø'];
+        $linesOfCode = ['key' => 'loc', 'label' => 'LOC'];
+        $evolution = ['key' => 'evolution', 'label' => 'Since'];
+
+        return match ($this) {
+            self::Stars => [$stars, $complexity, $evolution],
+            self::Complexity => [$complexity, $linesOfCode, $evolution],
+            self::Size => [$linesOfCode, ['key' => 'releases', 'label' => 'Releases'], $stars],
+            self::Growth => [['key' => 'growth', 'label' => '12M'], $complexity, $stars],
+        };
+    }
+
+    /**
+     * What those columns hold. A header cell has room for a word and no more, so `Ø`, `LOC` and `12M`
+     * are spelled out under the table rather than in a heading that would wrap - the caption says what
+     * the rows are ordered by, this says what is being read in them.
+     */
+    public function legend(): string
+    {
+        return match ($this) {
+            self::Stars => 'Ø is the average cyclomatic complexity of the latest analysed release; the last column is how it moved since the first one.',
+            self::Complexity => 'Ø is the average cyclomatic complexity of the latest analysed release and LOC its size; the last column is how the average moved since the first release.',
+            self::Size => 'LOC is the size of the latest analysed release as phploc counts it, next to how many releases were measured and how many stars the repository carries.',
+            self::Growth => '12M is how the average complexity moved within the last twelve months, Ø where it stands after that.',
+        };
+    }
+
+    /**
      * @param list<RankedRepository> $repositories
      *
      * @return list<RankedRepository>

--- a/src/ComplexityReport/Trend/Trend.php
+++ b/src/ComplexityReport/Trend/Trend.php
@@ -8,10 +8,27 @@ namespace App\ComplexityReport\Trend;
  * What the whole report did to its average complexity within one time frame.
  *
  * `from` and `to` are the mean average complexity over the libraries the window could compare - every
- * library counts once, no matter how many releases or lines of code it carries.
+ * library counts once, no matter how many releases or lines of code it carries. `series` is the same
+ * figure between those two ends, which is the line the hero draws under it.
  */
 final readonly class Trend
 {
+    /**
+     * Below a twentieth of a percent nothing moved - the same threshold the report colours a change by,
+     * so a figure printed grey is not narrated as a direction either.
+     */
+    private const float FLAT = 0.05;
+
+    /**
+     * Where "slightly" ends and where "much" begins. The figure is a mean over every library the window
+     * carries, so a tenth of it moving is a lot.
+     */
+    private const float SLIGHT = 2.0;
+    private const float LARGE = 10.0;
+
+    /**
+     * @param list<TrendPoint> $series the figure over time, oldest sample first
+     */
     public function __construct(
         public TrendWindow $window,
         public float $from,
@@ -29,6 +46,7 @@ final readonly class Trend
          * release.
          */
         public ?\DateTimeImmutable $since = null,
+        public array $series = [],
     ) {
     }
 
@@ -43,5 +61,30 @@ final readonly class Trend
     public function hasData(): bool
     {
         return $this->repositoryCount > 0;
+    }
+
+    /**
+     * The figure as a sentence rather than as a number - what the hero opens with, over the line it
+     * draws.
+     *
+     * Complexity is branchiness, so that is the word it is said in: code that "improved" or "regressed"
+     * would read a verdict into one metric, which is what the block explaining the report warns against.
+     * The degree is coarse on purpose - three steps, so a tenth of a percent is never dressed up.
+     */
+    public function movement(): string
+    {
+        $change = abs($this->change);
+
+        if ($change < self::FLAT) {
+            return 'held steady';
+        }
+
+        $degree = match (true) {
+            $change < self::SLIGHT => 'slightly ',
+            $change < self::LARGE => '',
+            default => 'much ',
+        };
+
+        return sprintf('got %s%s branchy', $degree, $this->change < 0 ? 'less' : 'more');
     }
 }

--- a/src/ComplexityReport/Trend/TrendCalculator.php
+++ b/src/ComplexityReport/Trend/TrendCalculator.php
@@ -17,11 +17,22 @@ namespace App\ComplexityReport\Trend;
  *   release it stood at when the window opened. A library that has not released since simply carries
  *   its last measurement forward, which is what the chart shows for it as well.
  *
+ * The same two decisions carry {@see self::series()}, which is the figure between its two ends rather
+ * than at them - so the line the hero draws starts on `from`, ends on `to`, and is a statement about
+ * the same libraries all the way through.
+ *
  * The class is pure on purpose: it takes a list of points and the current time and returns value
  * objects, so everything about it can be tested without a database or a clock.
  */
 final readonly class TrendCalculator
 {
+    /**
+     * How many steps the line between the two ends of a window is sampled in. The hero draws it 180px
+     * tall and a few hundred wide, so this is what it can show rather than what could be computed - and
+     * a window carries one sample more than this, since both ends are on it.
+     */
+    private const int STEPS = 24;
+
     /**
      * One trend per window, in the order {@see TrendWindow::all()} declares them.
      *
@@ -96,6 +107,89 @@ final readonly class TrendCalculator
             round((($toMean - $fromMean) / $fromMean) * 100, 1),
             \count($from),
             $start,
+            $this->series($points, array_keys($baseline), $start ?? $this->earliest($baseline), $now),
         );
+    }
+
+    /**
+     * The figure of a window over time: at every sample, the mean over the libraries it compares, each
+     * of them standing at the last release it had by then.
+     *
+     * It is the same set the figure is computed over, so the line ends where the figure does. All time
+     * is the exception it is everywhere else: there a library starts at its own first release rather
+     * than at a date they share, so the line begins with the oldest of them and the rest joins it as
+     * they were first measured - which is the dataset growing as much as it is the code changing, and
+     * why the windows with a start are the ones a shape can be read off.
+     *
+     * @param list<ReleasePoint> $points
+     * @param list<int>          $participants
+     *
+     * @return list<TrendPoint>
+     */
+    private function series(array $points, array $participants, \DateTimeImmutable $start, \DateTimeImmutable $now): array
+    {
+        $taking = array_fill_keys($participants, true);
+
+        /** @var array<int, list<ReleasePoint>> $releases */
+        $releases = [];
+
+        foreach ($points as $point) {
+            if ($point->created > $now || !isset($taking[$point->repository])) {
+                continue;
+            }
+
+            $releases[$point->repository][] = $point;
+        }
+
+        foreach ($releases as $repository => $ordered) {
+            usort($ordered, static fn (ReleasePoint $left, ReleasePoint $right) => $left->created <=> $right->created);
+            $releases[$repository] = $ordered;
+        }
+
+        $span = $now->getTimestamp() - $start->getTimestamp();
+        // a window that opened today has no line to draw, only the day it is on
+        $steps = $span > 0 ? self::STEPS : 0;
+
+        // the samples ascend and so do the releases, so every library is walked once across all of them
+        // rather than once per sample - this runs on every start page the cache does not answer
+        $cursors = array_fill_keys(array_keys($releases), 0);
+        $standing = [];
+        $series = [];
+
+        for ($step = 0; $step <= $steps; ++$step) {
+            $at = $start->modify(sprintf('%+d seconds', intdiv($span * $step, max(1, $steps))));
+
+            foreach ($releases as $repository => $ordered) {
+                $cursor = $cursors[$repository];
+
+                while (isset($ordered[$cursor]) && $ordered[$cursor]->created <= $at) {
+                    $standing[$repository] = $ordered[$cursor]->averageComplexity;
+                    ++$cursor;
+                }
+
+                $cursors[$repository] = $cursor;
+            }
+
+            if ([] !== $standing) {
+                $series[] = new TrendPoint($at, round(array_sum($standing) / \count($standing), 2));
+            }
+        }
+
+        return $series;
+    }
+
+    /**
+     * Where all time starts: the first release of the library that was measured furthest back.
+     *
+     * It is only ever asked about a window that compares something - a report without a single library
+     * to compare left before this, as a trend that has no data.
+     *
+     * @param non-empty-array<int, ReleasePoint> $baseline
+     */
+    private function earliest(array $baseline): \DateTimeImmutable
+    {
+        $dates = array_map(static fn (ReleasePoint $point) => $point->created, $baseline);
+
+        return min($dates);
     }
 }

--- a/src/ComplexityReport/Trend/TrendPoint.php
+++ b/src/ComplexityReport/Trend/TrendPoint.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Trend;
+
+/**
+ * One sample of {@see Trend::$series} - where the average complexity of the libraries a window compares
+ * stood on a given day.
+ *
+ * It is not a release: a sample is the mean over every library the window carries, each of them
+ * represented by the last release it had at that point. Which is why the report can have a line for a
+ * day nothing was released on.
+ */
+final readonly class TrendPoint
+{
+    public function __construct(
+        public \DateTimeImmutable $at,
+        public float $complexity,
+    ) {
+    }
+}

--- a/src/ComplexityReport/Trend/TrendWindow.php
+++ b/src/ComplexityReport/Trend/TrendWindow.php
@@ -50,6 +50,20 @@ enum TrendWindow: string
     }
 
     /**
+     * The window said in passing rather than named: "PHP open source got slightly less branchy
+     * <phrase>", which is the sentence the hero opens with. {@see self::title()} is the label of it.
+     */
+    public function phrase(): string
+    {
+        return match ($this) {
+            self::YearToDate => 'this year',
+            self::TwelveMonths => 'in the last 12 months',
+            self::FiveYears => 'in the last five years',
+            self::AllTime => 'since the first release of every library',
+        };
+    }
+
+    /**
      * When the window opens - `null` for all time, which starts at the first release of every library
      * rather than at a date they all share.
      */

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\ComplexityReport\Activity;
 use App\ComplexityReport\ChartSelection;
 use App\ComplexityReport\Exception\SubmissionFailed;
 use App\ComplexityReport\PhplocReport;
@@ -55,10 +56,22 @@ final class ReportController extends AbstractController
     private const int SEARCH_LIMIT = 8;
 
     /**
-     * Number of recently submitted repositories, and of recently measured releases, the start page
-     * closes with - the two lists stand next to each other, so they are the same length.
+     * How far back the strip closing the start page looks for submissions.
      */
     private const int LATEST_LIMIT = 12;
+
+    /**
+     * How far back it looks for measured releases, which is deeper than it shows on purpose: a worker
+     * measures a repository release by release, so the newest releases the report has are usually all
+     * of the same one - and the strip names a repository once.
+     */
+    private const int ACTIVITY_DEPTH = 64;
+
+    /**
+     * How many entries that strip is. It closes the page as one quiet line rather than as a section, so
+     * it is bounded by what fits on one.
+     */
+    private const int ACTIVITY_LIMIT = 8;
 
     #[Route('', name: 'start', methods: 'GET')]
     public function start(
@@ -80,8 +93,11 @@ final class ReportController extends AbstractController
             'rankings' => $rankings,
             'hasData' => [] !== $analysed,
             'vendors' => $organizationRepository->findVendors(),
-            'latest' => $repositoryRepository->findLatest(self::LATEST_LIMIT),
-            'latestReleases' => $tagRepository->findLatest(self::LATEST_LIMIT),
+            'activity' => Activity::feed(
+                $repositoryRepository->findLatest(self::LATEST_LIMIT),
+                $tagRepository->findLatest(self::ACTIVITY_DEPTH),
+                self::ACTIVITY_LIMIT,
+            ),
             'statistics' => $statisticsLoader->load(),
             'trends' => $trendLoader->load(),
         ]);

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -72,16 +72,23 @@ final class AppExtension extends AbstractExtension
 
     /**
      * A complexity change with its direction spelled out.
+     *
+     * The arrow is for a figure standing on its own. In a column of them every sign is already lined up
+     * under the sign above it and the colour says the direction as well, so the table drops it rather
+     * than saying the same thing three times per row.
      */
-    public function formatSignedPercent(float $value): string
+    public function formatSignedPercent(float $value, bool $arrow = true): string
     {
-        $sign = match ($this->trendTone($value)) {
-            'good' => '↓ −',
-            'bad' => '↑ +',
-            default => '→ ±',
+        $tone = $this->trendTone($value);
+        $sign = match ($tone) {
+            'good' => '−',
+            'bad' => '+',
+            default => '±',
         };
 
-        return $sign.number_format(abs($value), 1, '.', '').'%';
+        $arrows = ['good' => '↓ ', 'bad' => '↑ ', 'flat' => '→ '];
+
+        return ($arrow ? $arrows[$tone] : '').$sign.number_format(abs($value), 1, '.', '').'%';
     }
 
     /**

--- a/templates/_search.html.twig
+++ b/templates/_search.html.twig
@@ -1,0 +1,29 @@
+{#
+ # The one box the report is navigated by, in the top band of every screen. It does both jobs it always
+ # did - it finds what the report carries, and it takes anything that identifies a repository on
+ # github.com so it can be submitted - it just does them from where every screen can reach it rather
+ # than from a band of its own on the start page.
+ #
+ # Without javascript there are no suggestions and no shortcut, and the box is a form that posts what
+ # was typed to `submit`, which is what it was before the suggestions existed.
+ #}
+<form action="{{ path('submit') }}" method="post" class="site-search"
+      {{ stimulus_controller('search', { url: path('search') }) }}>
+    <input type="hidden" name="_token" value="{{ csrf_token('submit') }}" data-controller="csrf-protection">
+    <div class="combobox">
+        <div class="site-search__control">
+            {# what the key does is drawn on the key, so the shortcut is not something to be told about #}
+            <span class="site-search__key" aria-hidden="true">/</span>
+            <input type="text" name="repository" class="site-search__input" required
+                   placeholder="Search the report, or paste owner/repository"
+                   aria-label="Search or add a GitHub repository"
+                   autocomplete="off" autocapitalize="off" spellcheck="false"
+                   role="combobox" aria-expanded="false" aria-autocomplete="list"
+                   aria-controls="search-suggestions"
+                   data-search-target="input"
+                   data-action="input->search#query keydown->search#navigate focus->search#query blur->search#close">
+        </div>
+        <ul class="combobox__menu" id="search-suggestions" role="listbox"
+            aria-label="Repositories" data-search-target="menu" hidden></ul>
+    </div>
+</form>

--- a/templates/about.html.twig
+++ b/templates/about.html.twig
@@ -1,5 +1,5 @@
 {#
- # What the report does not say by itself, on both screens rather than on a page of its own: what its
+ # What the report does not say by itself, closing the screen that shows it at a glance: what its
  # numbers mean, how one gets into it, and what it is worth. The last part is the one that matters - a
  # line going up reads as a verdict unless it says next to it that this is one metric among many, and
  # that parts of the data are known to be off.
@@ -7,72 +7,102 @@
  # The scale opens the block, across both columns: it is what every number of the report is read
  # against, so it comes before the texts explaining where those numbers come from - and at half the
  # width every band would set its risk in two lines.
+ #
+ # Under it the two columns say the short version. The long one is every caveat spelled out - worth
+ # reading once and worth being able to point at, but not worth a screenful under a report somebody
+ # came to read - so it is folded away behind the sentence introducing it.
  #}
 <section class="about">
     <div class="wrap about__inner">
-        <section class="about__section about__scale">
-            <h2 class="eyebrow">Complexity levels</h2>
-            {{ include('complexity_scale.html.twig') }}
-        </section>
-        <section class="about__section">
-            <h2 class="eyebrow">How the report is made</h2>
-            <p>
-                Anyone can submit a repository - github.com is the only source, and no
-                <code>composer.json</code> is needed. A submission is turned down when the
-                repository is unknown, a fork, empty, larger than 10&nbsp;GB, or less than 20%
-                PHP by the language breakdown github.com reports for it; everything else is
-                queued for a worker.
-            </p>
-            <p>
-                The worker clones it and checks out its release tags one after another. Only
-                major and minor releases are measured (<code>5.4</code>, <code>5.4.0</code>) -
-                patch releases and pre-releases (anything carrying a <code>-</code>) are skipped,
-                as are a handful of releases whose date git cannot tell straight. On every
-                checkout,
-                <a href="https://github.com/sebastianbergmann/phploc" target="_blank" rel="noreferrer">phploc</a>
-                reads every <code>.php</code> file of the working copy and leaves two numbers
-                behind: lines of code, and the average cyclomatic complexity of a class, dated by
-                the last commit that tag points at. The clone is deleted afterwards, the numbers
-                stay.
-            </p>
-            <p>
-                From then on the report keeps itself current: every night it refreshes stars and
-                asks github.com which releases are missing, so a new minor turns up in the chart
-                by itself - and a repository that did not release is not even cloned.
-            </p>
-        </section>
-        <section class="about__section">
-            <h2 class="eyebrow">About cyclomatic complexity</h2>
-            <p>
-                Cyclomatic complexity counts the paths through a piece of code: one, plus one for
-                every branch - <code>if</code>, <code>case</code>, <code>while</code>,
-                <code>for</code>, <code>catch</code>, <code>&amp;&amp;</code>, <code>||</code>.
-                Code without a single condition scores 1. What is charted here is the average
-                over all classes of a release, so it says how branchy the average class of a
-                library is - not how large it is, and not how good it is.
-            </p>
-            <p>
-                It is one metric, and worth what a metric is worth. It travels well as a rough
-                measure of how many paths a test suite has to cover, and badly as a verdict: a
-                clear class holding one big <code>match</code> outscores a tangle of indirection
-                nobody can follow, and pushing branches into polymorphism lowers the figure
-                without lowering the thinking. The shape of a line over the years says more than
-                any point on it.
-            </p>
-            <p>
-                The data has its glitches, too. Whatever sits in a repository at a tag is
-                measured, so committed dependencies, generated code and test suites count towards
-                the average. Libraries that were split, renamed or imported from another version
-                control system - Zend&nbsp;→&nbsp;Laminas, the early PHPUnit tags - carry dates
-                and jumps their git history cannot explain. And a gap in a line is a release
-                that was left out or could not be measured - not one that never happened.
-            </p>
-            <p class="about__links">
-                Further reading:
-                <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity" target="_blank" rel="noreferrer">Wikipedia</a>,
-                <a href="https://ieeexplore.ieee.org/document/1702388" target="_blank" rel="noreferrer">McCabe, A Complexity Measure (1976)</a>,
-                <a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication500-235.pdf" target="_blank" rel="noreferrer">NIST 500-235</a>.
-            </p>
-        </section>
+        <h2 class="eyebrow about__label">What the numbers mean</h2>
+        {{ include('complexity_scale.html.twig') }}
+
+        <div class="about__columns" {{ stimulus_controller('disclosure') }}>
+            <section class="about__section">
+                <h3 class="eyebrow">How the report is made</h3>
+                <p>
+                    Anyone submits a repository, a worker clones it and checks out every major and minor
+                    release, and
+                    <a href="https://github.com/sebastianbergmann/phploc" target="_blank" rel="noreferrer">phploc</a>
+                    reads every <code>.php</code> file of it: lines of code, and the average cyclomatic
+                    complexity of a class. The clone is deleted, the numbers stay. Every night the report
+                    asks github.com what it is missing.
+                </p>
+            </section>
+            <section class="about__section">
+                <h3 class="eyebrow">What it is worth</h3>
+                <p>
+                    Complexity counts the paths through a class - it says how branchy the average class of
+                    a library is, not how large or how good it is. Committed dependencies and generated
+                    code count towards it, and libraries that were split or renamed carry jumps their git
+                    history cannot explain.
+                </p>
+                {#
+                 # Rendered open and without the button, so a browser that does not run the controller
+                 # keeps the whole text - folding it away is the enhancement, and so is what opens it.
+                 #}
+                <p class="about__reveal">
+                    <button type="button" class="about__more" aria-expanded="true" aria-controls="about-long" hidden
+                            data-disclosure-target="toggle" data-action="disclosure#toggle">The long version</button>
+                </p>
+            </section>
+
+            <div class="about__long" id="about-long" data-disclosure-target="panel">
+                <section class="about__section">
+                    <h3 class="eyebrow">How a repository gets in</h3>
+                    <p>
+                        github.com is the only source, and no <code>composer.json</code> is needed. A
+                        submission is turned down when the repository is unknown, a fork, empty, larger
+                        than 10&nbsp;GB, or less than 20% PHP by the language breakdown github.com reports
+                        for it; everything else is queued for a worker.
+                    </p>
+                    <p>
+                        The worker clones it and checks out its release tags one after another. Only major
+                        and minor releases are measured (<code>5.4</code>, <code>5.4.0</code>) - patch
+                        releases and pre-releases (anything carrying a <code>-</code>) are skipped, as are
+                        a handful of releases whose date git cannot tell straight. On every checkout phploc
+                        reads every <code>.php</code> file of the working copy and leaves two numbers
+                        behind, dated by the last commit that tag points at.
+                    </p>
+                    <p>
+                        From then on the report keeps itself current: every night it refreshes stars and
+                        asks github.com which releases are missing, so a new minor turns up in the chart by
+                        itself - and a repository that did not release is not even cloned.
+                    </p>
+                </section>
+                <section class="about__section">
+                    <h3 class="eyebrow">About cyclomatic complexity</h3>
+                    <p>
+                        Cyclomatic complexity counts the paths through a piece of code: one, plus one for
+                        every branch - <code>if</code>, <code>case</code>, <code>while</code>,
+                        <code>for</code>, <code>catch</code>, <code>&amp;&amp;</code>, <code>||</code>.
+                        Code without a single condition scores 1. What is charted here is the average over
+                        all classes of a release.
+                    </p>
+                    <p>
+                        It is one metric, and worth what a metric is worth. It travels well as a rough
+                        measure of how many paths a test suite has to cover, and badly as a verdict: a
+                        clear class holding one big <code>match</code> outscores a tangle of indirection
+                        nobody can follow, and pushing branches into polymorphism lowers the figure without
+                        lowering the thinking. The shape of a line over the years says more than any point
+                        on it.
+                    </p>
+                    <p>
+                        The data has its glitches, too. Whatever sits in a repository at a tag is measured,
+                        so committed dependencies, generated code and test suites count towards the
+                        average. Libraries that were split, renamed or imported from another version
+                        control system - Zend&nbsp;→&nbsp;Laminas, the early PHPUnit tags - carry dates and
+                        jumps their git history cannot explain. And a gap in a line is a release that was
+                        left out or could not be measured - not one that never happened.
+                    </p>
+                    <p class="about__links">
+                        Further reading:
+                        <a href="https://en.wikipedia.org/wiki/Cyclomatic_complexity" target="_blank" rel="noreferrer">Wikipedia</a>,
+                        <a href="https://ieeexplore.ieee.org/document/1702388" target="_blank" rel="noreferrer">McCabe, A Complexity Measure (1976)</a>,
+                        <a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication500-235.pdf" target="_blank" rel="noreferrer">NIST 500-235</a>.
+                    </p>
+                </section>
+            </div>
+        </div>
     </div>
 </section>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -17,33 +17,61 @@
     </head>
     <body>
         {#
-         # The top band of every page: the mark next to the wordmark on the left, a mono nav on the
-         # right. Two screens, so two items - the report at a glance, and the chart it is read in. The
-         # first one is not called after what it lists: the chart lists repositories too, and only the
-         # start screen carries the trend, the search and the queue alongside them.
+         # The top band of every page: the mark next to the wordmark on the left, the box the report is
+         # searched and added to in the middle, a mono nav on the right. Two screens, so two items - the
+         # report at a glance, and the chart it is read in. The first one is not called after what it
+         # lists: the chart lists repositories too, and only the start screen carries the trend and the
+         # rankings alongside them.
+         #
+         # The box stands here rather than in a band of its own on the start page, because it is how
+         # every screen is left: a repository is looked up from wherever it was thought of.
          #}
         {% set route = app.request.attributes.get('_route') %}
         <header class="site-header">
             <div class="wrap site-header__inner">
                 <a class="site-header__brand" href="{{ path('start') }}">
-                    {{ include('mark.html.twig', {size: 30}) }}
+                    {{ include('mark.html.twig', {size: 28}) }}
                     <span class="logo">
                         <span class="logo__title">Complexity Report</span>
                         <span class="logo__kicker">Open Source PHP Software</span>
                     </span>
                 </a>
-                <div class="site-header__right">
-                    <nav class="site-header__nav">
-                        <a class="site-header__link {{ route == 'start' ? 'is-active' }}"
-                           href="{{ path('start') }}">Overview</a>
-                        <a class="site-header__link {{ route == 'chart' ? 'is-active' }}"
-                           href="{{ path('chart') }}">Chart</a>
-                        <a class="site-header__link" target="_blank" rel="noreferrer"
-                           href="https://github.com/chr-hertel/oss-complexity-report">GitHub</a>
-                    </nav>
-                </div>
+                {{ include('_search.html.twig') }}
+                <nav class="site-header__nav">
+                    <a class="site-header__link {{ route == 'start' ? 'is-active' }}"
+                       href="{{ path('start') }}">Overview</a>
+                    <a class="site-header__link {{ route == 'chart' ? 'is-active' }}"
+                       href="{{ path('chart') }}">Chart</a>
+                    <a class="site-header__link" target="_blank" rel="noreferrer"
+                       href="https://github.com/chr-hertel/oss-complexity-report">GitHub</a>
+                </nav>
             </div>
         </header>
+        {#
+         # What a submission was answered with. It used to stand in the band the box stood in; now that
+         # the box is in the header, its answers are directly under it - which is where someone who just
+         # pressed return is looking, on whichever screen they end up on.
+         #}
+        {#
+         # Asked for only when there can be one: reading the flash bag starts a session, and the report
+         # is read by people who never submitted anything. A cookie is what a redirect back from `submit`
+         # leaves behind, so it is what says there is something to read - and `app.flashes` answers with
+         # a key per type whether or not it holds anything, which is why the empty ones are dropped.
+         #}
+        {% set flashes = app.request.hasPreviousSession
+            ? app.flashes(['success', 'danger'])|filter(messages => messages is not empty)
+            : [] %}
+        {% if flashes is not empty %}
+            <div class="flash-band">
+                <div class="wrap">
+                    {% for label, messages in flashes %}
+                        {% for message in messages %}
+                            <div class="alert alert--{{ label }}">{{ message }}</div>
+                        {% endfor %}
+                    {% endfor %}
+                </div>
+            </div>
+        {% endif %}
         {% block content %}{% endblock %}
         {#
          # The credits, and nothing else: what the report is and what its numbers are worth is

--- a/templates/chart.html.twig
+++ b/templates/chart.html.twig
@@ -12,17 +12,19 @@
      # The one chart of the report. It is not named after the way it was reached but after what is in it,
      # and since that changes without leaving the page, the controller reaches up to the headline - which
      # is why it wraps the whole screen rather than only the chart.
+     #
+     # That headline is not printed anymore: what the chart holds is the row of chips above it, said in
+     # the colours the lines are drawn in, and a title repeating them was the third place saying the
+     # same thing. It is still what the document is called and what a reader that does not look at the
+     # screen opens on, so it is carried rather than dropped.
      #}
     <main class="page">
         <div class="wrap page__body" data-controller="chart"
              data-repositories="{{ series|map(repository => repository.asGraph)|json_encode|e('html_attr') }}">
-            <div class="eyebrow">Chart</div>
-            <h1 class="chart-title">
+            <h1 class="visually-hidden">
                 <span data-chart-target="headline">{{ selection.headline }}</span>
-                <a class="chart-title__link" target="_blank" rel="noreferrer" data-chart-target="headlineLink"
-                   {% if selection.url %}href="{{ selection.url }}" title="{{ selection.url|replace({'https://':''}) }}"{% else %}hidden{% endif %}>
-                    <i class="fas fa-arrow-up-right-from-square"></i>
-                </a>
+                <a data-chart-target="headlineLink"
+                   {% if selection.url %}href="{{ selection.url }}"{% else %}hidden{% endif %}>on GitHub</a>
             </h1>
 
             {#
@@ -71,7 +73,7 @@
                         <div class="eyebrow">Release analysis</div>
                         <div class="panel panel--pad-lg" style="margin-top: var(--space-5)">
                             <div class="analysis" aria-hidden="true">
-                                {% for group in 1..4 %}
+                                {% for group in 1..3 %}
                                     <div>
                                         <div class="analysis__title">
                                             <span class="skeleton__line" style="width: 40%"></span>
@@ -95,79 +97,65 @@
                     </section>
                 </div>
             {% elseif series is not empty %}
-                <div>
-                    {# what a point is; what it is drawn as is said by the switch above the chart #}
-                    <p class="chart-lead">
-                        One point per analysed release, measured with phploc. Scroll
-                        to zoom, drag to pan,
-                        and click a release to read it below.
-                    </p>
-
+                <div {{ stimulus_controller('repository-picker') }}>
                     {#
-                     # What the chart is drawn from stands above it: everything the report carries can be
-                     # added here, whoever owns it - the box is the whole navigation of this screen, and
-                     # what is picked ends up in the query string. The headline says what it is, so the
-                     # box needs no second one.
+                     # The state the box is a widget for: what is in the chart, and in which order it is
+                     # drawn. The chart reads this and redraws on its `change`, so it does not care how a
+                     # repository got in or out.
                      #}
-                    <div class="repository-picker" {{ stimulus_controller('repository-picker') }}>
-                        {#
-                         # The state the box is a widget for: what is in the chart, and in which order it
-                         # is drawn. The chart reads this and redraws on its `change`, so it does not
-                         # care how a repository got in or out.
-                         #}
-                        <select name="repositories[]" multiple="multiple" hidden
-                                data-chart-target="select" data-repository-picker-target="select"
-                                data-action="change->chart#repick">
-                            {% for repository in selection.options %}
-                                <option value="{{ repository.name }}" {{ repository in series ? 'selected="selected"' }}>{{ repository.name }}</option>
-                            {% endfor %}
-                        </select>
-                        {# the same box as the search on the start page, with room for more than one answer #}
-                        <div class="combobox">
-                            <div class="combobox__control" data-action="click->repository-picker#focus">
-                                <ul class="combobox__chips" data-repository-picker-target="chips"></ul>
-                                <input type="text" class="combobox__input"
-                                       placeholder="Search the report"
-                                       aria-label="Repositories in this chart"
-                                       autocomplete="off" autocapitalize="off" spellcheck="false"
-                                       role="combobox" aria-expanded="false" aria-autocomplete="list"
-                                       aria-controls="repository-suggestions"
-                                       data-repository-picker-target="input"
-                                       data-action="input->repository-picker#query focus->repository-picker#query keydown->repository-picker#navigate blur->repository-picker#close">
-                            </div>
-                            <ul class="combobox__menu" id="repository-suggestions" role="listbox"
-                                aria-label="Repositories the report carries"
-                                data-repository-picker-target="menu" hidden></ul>
-                        </div>
-                        <p class="repository-picker__hint">
-                            As many lines as the report carries - one colour each, dashed once the eight
-                            colours start over.
-                            <a href="{{ path('start') }}">Add a repository</a> the report does not carry yet.
-                        </p>
-                    </div>
-
-                    {#
-                     # What the same lines are drawn as. A release is measured in two numbers and the
-                     # report is about one of them, so complexity is what the chart opens on - but the
-                     # other one is measured just as well, and reading a codebase growing under a
-                     # complexity that holds is a different statement than either number alone. What is
-                     # picked ends up in the query string next to the repositories, because it is part
-                     # of the chart somebody put together.
-                     #}
-                    <div class="chart-metrics" role="tablist" aria-label="What the chart draws">
-                        <button type="button" class="metric-switch" role="tab" aria-selected="true"
-                                aria-controls="chart-canvas" data-metric="complexity"
-                                data-chart-target="metric" data-action="chart#selectMetric">
-                            Ø complexity
-                        </button>
-                        <button type="button" class="metric-switch" role="tab" aria-selected="false"
-                                aria-controls="chart-canvas" data-metric="loc"
-                                data-chart-target="metric" data-action="chart#selectMetric">
-                            Lines of code
-                        </button>
-                    </div>
+                    <select name="repositories[]" multiple="multiple" hidden
+                            data-chart-target="select" data-repository-picker-target="select"
+                            data-action="change->chart#repick">
+                        {% for repository in selection.options %}
+                            <option value="{{ repository.name }}" {{ repository in series ? 'selected="selected"' }}>{{ repository.name }}</option>
+                        {% endfor %}
+                    </select>
 
                     <div class="panel chart-panel">
+                        {#
+                         # What the chart is drawn from and what it draws it as, on the top edge of the
+                         # panel it does both in. The chips are the lines - each one in the colour of its
+                         # series, which is what a legend under the chart used to say - and the field
+                         # after them is where another one is added.
+                         #}
+                        <div class="chart-panel__head">
+                            <div class="combobox chart-panel__picker">
+                                <div class="combobox__control" data-action="click->repository-picker#focus">
+                                    <ul class="combobox__chips" data-repository-picker-target="chips"></ul>
+                                    <input type="text" class="combobox__input"
+                                           placeholder="+ add a line"
+                                           aria-label="Repositories in this chart"
+                                           autocomplete="off" autocapitalize="off" spellcheck="false"
+                                           role="combobox" aria-expanded="false" aria-autocomplete="list"
+                                           aria-controls="repository-suggestions"
+                                           data-repository-picker-target="input"
+                                           data-action="input->repository-picker#query focus->repository-picker#query keydown->repository-picker#navigate blur->repository-picker#close">
+                                </div>
+                                <ul class="combobox__menu" id="repository-suggestions" role="listbox"
+                                    aria-label="Repositories the report carries"
+                                    data-repository-picker-target="menu" hidden></ul>
+                            </div>
+
+                            {#
+                             # What the same lines are drawn as. A release is measured in two numbers and
+                             # the report is about one of them, so complexity is what the chart opens on -
+                             # but reading a codebase growing under a complexity that holds is a different
+                             # statement than either number alone.
+                             #}
+                            <div class="chart-metrics" role="tablist" aria-label="What the chart draws">
+                                <button type="button" class="metric-switch" role="tab" aria-selected="true"
+                                        aria-controls="chart-canvas" data-metric="complexity"
+                                        data-chart-target="metric" data-action="chart#selectMetric">
+                                    Ø complexity
+                                </button>
+                                <button type="button" class="metric-switch" role="tab" aria-selected="false"
+                                        aria-controls="chart-canvas" data-metric="loc"
+                                        data-chart-target="metric" data-action="chart#selectMetric">
+                                    Lines of code
+                                </button>
+                            </div>
+                        </div>
+
                         <div class="chart-canvas" id="chart-canvas" role="tabpanel">
                             <canvas data-chart-target="canvas"></canvas>
                             {#
@@ -180,79 +168,88 @@
                                 <i class="fas fa-arrows-to-dot"></i> Reset zoom
                             </button>
                         </div>
+
+                        {# what a point is, and how much of the report is on this one #}
+                        <div class="chart-panel__foot">
+                            <span>Scroll to zoom, drag to pan, click a release to read it below.</span>
+                            <span class="chart-panel__count" data-chart-target="count">
+                                {{ series|length }} {{ series|length == 1 ? 'repository' : 'repositories' }} ·
+                                {{ selection.releaseCount|number_format }}
+                                {{ selection.releaseCount == 1 ? 'release' : 'releases' }}
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                {#
+                 # One tab per line of the chart: every repository in it can be read release by release,
+                 # not only the one the page was opened with. The tabs are built by the controller, since
+                 # what is in the chart changes without leaving the page - and what picks a release out of
+                 # the one being read sits on the same rail, because both of them choose what the panel
+                 # below shows.
+                 #}
+                <section class="section release" data-chart-target="release" hidden>
+                    <div class="release__rail">
+                        <div class="tabs tabs--series" role="tablist" aria-label="Repositories in this chart"
+                             data-chart-target="releaseTabs"></div>
+                        <div class="release__actions">
+                            {#
+                             # The repository being read, on github.com. It used to hang off the headline
+                             # of the screen; the headline is gone, and this is where what is being read
+                             # is named now.
+                             #}
+                            <a class="release__link" target="_blank" rel="noreferrer"
+                               data-chart-target="releaseLink"><i class="fas fa-arrow-up-right-from-square"></i></a>
+                            <select class="release-select" aria-label="Release"
+                                    data-chart-target="releaseSelect" data-action="chart#selectRelease"></select>
+                            {#
+                             # The panel below is the handful of numbers the report has an opinion about;
+                             # a phploc run counts sixty. The rest is not summarised anywhere, it is shown
+                             # as phploc printed it.
+                             #}
+                            <button type="button" class="btn btn--secondary" data-action="chart#openRaw">
+                                <i class="fas fa-terminal"></i> Raw output
+                            </button>
+                        </div>
                     </div>
 
                     {#
-                     # One tab per line of the chart: every repository in it can be read release by
-                     # release, not only the one the page was opened with. The tabs are built by the
-                     # controller, since what is in the chart changes without leaving the page.
+                     # What the release being read comes down to, before the panel spelling it out: where
+                     # it stands, what it did against the release before it, how large it is, and how much
+                     # of the repository has been measured.
                      #}
-                    <section class="section" data-chart-target="release" hidden>
-                        <div class="eyebrow">Release analysis</div>
-                        <div class="tabs tabs--series" role="tablist" aria-label="Repositories in this chart"
-                             data-chart-target="releaseTabs"></div>
-                        <div class="release-head">
-                            <div>
-                                <h2>
-                                    {# the repository being read is where it is read on github.com #}
-                                    <a class="release-head__name" target="_blank" rel="noreferrer"
-                                       data-chart-target="releaseRepository"></a>
-                                    <span class="badge" data-chart-target="releaseName"></span>
-                                </h2>
-                                <div class="release-head__meta" data-chart-target="releaseMeta"></div>
-                            </div>
-                            <div class="release-head__actions">
-                                {#
-                                 # The panel below is the handful of numbers the report has an opinion
-                                 # about; a phploc run counts sixty. The rest is not summarised anywhere,
-                                 # it is shown as phploc printed it.
-                                 #}
-                                <button type="button" class="btn btn--secondary"
-                                        data-action="chart#openRaw">
-                                    <i class="fas fa-terminal"></i> Raw phploc output
-                                </button>
-                                <select class="release-select" aria-label="Release"
-                                        data-chart-target="releaseSelect" data-action="chart#selectRelease"></select>
-                            </div>
-                        </div>
-                        <div class="panel panel--pad-lg" role="tabpanel" data-chart-target="releasePanel">
-                            <div class="analysis" data-chart-target="analysis"></div>
-                        </div>
+                    <div class="headline-figures" data-chart-target="headlineFigures"></div>
 
-                        {#
-                         # The whole measurement, as the phploc command line prints it. It is a modal
-                         # because it is a detour off the release being read and not a second place to
-                         # read one: the panel behind it stays on the release it was opened from.
-                         #}
-                        <dialog class="raw" aria-labelledby="raw-title"
-                                data-chart-target="raw" data-action="click->chart#dismissRaw">
-                            <div class="raw__head">
-                                <div>
-                                    <div class="eyebrow">phploc output</div>
-                                    <h2 class="raw__title" id="raw-title" data-chart-target="rawTitle"></h2>
-                                </div>
-                                <button type="button" class="raw__close" aria-label="Close"
-                                        data-action="chart#closeRaw">
-                                    <i class="fas fa-xmark"></i>
-                                </button>
+                    <div class="panel panel--pad-lg" role="tabpanel" data-chart-target="releasePanel">
+                        <div class="analysis" data-chart-target="analysis"></div>
+                    </div>
+
+                    {#
+                     # The whole measurement, as the phploc command line prints it. It is a modal because
+                     # it is a detour off the release being read and not a second place to read one: the
+                     # panel behind it stays on the release it was opened from.
+                     #}
+                    <dialog class="raw" aria-labelledby="raw-title"
+                            data-chart-target="raw" data-action="click->chart#dismissRaw">
+                        <div class="raw__head">
+                            <div>
+                                <div class="eyebrow">phploc output</div>
+                                <h2 class="raw__title" id="raw-title" data-chart-target="rawTitle"></h2>
                             </div>
-                            {# a report of aligned columns, so it is shown in the font it was aligned for #}
-                            <pre class="raw__output" tabindex="0" data-chart-target="rawOutput"></pre>
-                        </dialog>
-                    </section>
-                </div>
+                            <button type="button" class="raw__close" aria-label="Close"
+                                    data-action="chart#closeRaw">
+                                <i class="fas fa-xmark"></i>
+                            </button>
+                        </div>
+                        {# a report of aligned columns, so it is shown in the font it was aligned for #}
+                        <pre class="raw__output" tabindex="0" data-chart-target="rawOutput"></pre>
+                    </dialog>
+                </section>
             {% else %}
                 <p class="chart-lead empty-state">
-                    Nothing measured yet - <a href="{{ path('start') }}">add the first repository</a>.
+                    Nothing measured yet - the box above takes the first repository.
                 </p>
             {% endif %}
         </div>
     </main>
-
-    {#
-     # What the chart does not say by itself closes this screen, below the release analysis. It stands
-     # outside the page rather than in it, because the credits follow it directly and the two are read
-     # as one band.
-     #}
-    {{ include('about.html.twig') }}
 {% endblock %}

--- a/templates/start.html.twig
+++ b/templates/start.html.twig
@@ -1,175 +1,135 @@
 {% extends 'base.html.twig' %}
 
 {#
- # The metrics under a card follow the ranking it is shown in: whatever the tab sorts by comes first,
- # so the order the cards are in is readable off the cards themselves.
+ # One measured figure of a ranking row. Which three a table prints, and in which order, is
+ # `Ranking::columns()` - whatever the tab sorts by comes first, so the order the rows are in is
+ # readable off the rows themselves.
  #}
-{% macro metrics(ranked, ranking) %}
-    {% set stars %}
-        <span class="metric metric--star" title="{{ ranked.repository.stars }} stars on GitHub">
+{% macro figure(ranked, key) %}
+    {% if key == 'stars' %}
+        <span class="ranking-table__cell" title="{{ ranked.repository.stars|number_format }} stars on GitHub">
             <i class="fas fa-star"></i>{{ ranked.repository.stars|stars }}
         </span>
-    {% endset %}
-    {#
-     # The dot says which band of the footer scale this average falls into, and it stands where the Ø
-     # stood: a metric leads with one glyph, and on a card there is room for one - the title says in
-     # words what the dot means and that the number is an average.
-     #}
-    {% set complexity %}
+    {% elseif key == 'complexity' %}
+        {#
+         # The dot says which band of the scale below this average falls into, and it stands where the Ø
+         # of the column header stands: the header names the metric once, the dot places every number
+         # in it.
+         #}
         {% set level = ranked.complexity|complexity_level %}
-        <span class="metric level level--{{ level.value }}"
+        <span class="ranking-table__cell ranking-table__cell--strong level level--{{ level.value }}"
               title="Average cyclomatic complexity of the latest analysed release - {{ level.range }}: {{ level.risk|lower }}">
             {{- ranked.complexity|number_format(2) -}}
         </span>
-    {% endset %}
-    {% set linesOfCode %}
-        <span class="metric" title="{{ ranked.linesOfCode|number_format }} lines of code in the latest analysed release">
-            <span class="metric__label">LOC</span>{{ ranked.linesOfCode|compact_number }}
+    {% elseif key == 'loc' %}
+        <span class="ranking-table__cell" title="{{ ranked.linesOfCode|number_format }} lines of code in the latest analysed release">
+            {{ ranked.linesOfCode|compact_number }}
         </span>
-    {% endset %}
-    {% set releases %}
-        <span class="metric" title="Releases analysed so far">
-            <span class="metric__label">RELEASES</span>{{ ranked.releaseCount }}
+    {% elseif key == 'releases' %}
+        <span class="ranking-table__cell" title="Releases analysed so far">{{ ranked.releaseCount }}</span>
+    {% elseif key == 'evolution' %}
+        <span class="ranking-table__cell ranking-table__cell--{{ ranked.evolution|trend_tone }}"
+              title="Change in average complexity since {{ ranked.firstRelease }} ({{ ranked.firstReleased|date('F Y') }}) - down is an improvement">
+            {{ ranked.evolution|signed_percent(false) }}
         </span>
-    {% endset %}
-    {% set evolution %}
-        <span class="metric metric--{{ ranked.evolution|trend_tone }}"
-              title="Change in average complexity since {{ ranked.firstRelease }} - down is an improvement">
-            <span class="metric__label">since {{ ranked.firstReleased|date('Y') }}</span>{{ ranked.evolution|signed_percent }}
-        </span>
-    {% endset %}
-
-    {% set growth %}
-        <span class="metric metric--{{ ranked.recentEvolution|trend_tone }}"
-              title="Change in average complexity within the last 12 months - measured against the release it stood at back then">
-            <span class="metric__label">12M</span>{{ ranked.recentEvolution|signed_percent }}
-        </span>
-    {% endset %}
-
-    {% if ranking == 'stars' %}
-        {{ stars }}{{ complexity }}{{ evolution }}
-    {% elseif ranking == 'complexity' %}
-        {{ complexity }}{{ linesOfCode }}{{ evolution }}
-    {% elseif ranking == 'size' %}
-        {{ linesOfCode }}{{ releases }}{{ stars }}
     {% else %}
-        {{ growth }}{{ complexity }}{{ stars }}
+        <span class="ranking-table__cell ranking-table__cell--{{ ranked.recentEvolution|trend_tone }}"
+              title="Change in average complexity within the last 12 months - measured against the release it stood at back then">
+            {{ ranked.recentEvolution|signed_percent(false) }}
+        </span>
     {% endif %}
 {% endmacro %}
 
 {#
- # The tag the three lists closing the page are built from: a name and the one thing said about it,
- # joined into one pill. What the dark half carries is all that differs between them - a count, a
- # version, a state - so they are read the same way.
+ # A repository as one line of the ranking: where it stands, what it is called, what it says in
+ # numbers, and the way out to github.com. The cards this replaces gave every repository a box of its
+ # own, which read as nine things rather than as an order.
  #}
-{% macro pill(name, value, url, title, state = false) %}
-    <a class="pill" href="{{ url }}" title="{{ title }}">
-        <span class="pill__name">{{ name }}</span>
-        {% if value is not empty %}
-            <span class="pill__value{{ state ? ' pill__value--state' }}">{{ value }}</span>
-        {% endif %}
-    </a>
-{% endmacro %}
-
-{#
- # Owner above name on every card, the way github.com reads them - `symfony/symfony` saying its name
- # twice is what that repository is called, and dropping the line for it only left the head empty.
- #}
-{% macro card(ranked, ranking, rank) %}
+{% macro row(ranked, ranking, rank) %}
     {% set repository = ranked.repository %}
-    <div class="repo-card">
-        <div class="repo-card__body">
-            <div class="repo-card__head">
-                <span class="repo-card__rank">{{ rank < 10 ? '0' }}{{ rank }}</span>
-                <span class="repo-card__vendor">{{ repository.organization.login }}</span>
-            </div>
-            <h3 class="repo-card__title">
-                <a href="{{ path('chart', {'repositories': repository.name}) }}">
-                    {{ repository.shortName }}
-                </a>
-            </h3>
-            <p class="repo-card__text">{{ repository.description }}</p>
-        </div>
-        <div class="repo-card__meta">
-            {{ _self.metrics(ranked, ranking) }}
-            <a href="{{ repository.url }}" target="_blank" rel="noreferrer" class="repo-card__github"
-               title="{{ repository.name }} on GitHub">
-                <i class="fab fa-github"></i>
-            </a>
-        </div>
+    <div class="ranking-table__row">
+        <span class="ranking-table__rank">{{ rank < 10 ? '0' }}{{ rank }}</span>
+        <span class="ranking-table__repository">
+            <a class="ranking-table__name" href="{{ path('chart', {'repositories': repository.name}) }}">{{ repository.name }}</a>
+            <span class="ranking-table__description">{{ repository.description }}</span>
+        </span>
+        {% for column in ranking.columns %}
+            {{ _self.figure(ranked, column.key) }}
+        {% endfor %}
+        <a class="ranking-table__github" href="{{ repository.url }}" target="_blank" rel="noreferrer"
+           title="{{ repository.name }} on GitHub" aria-label="{{ repository.name }} on GitHub">
+            <i class="fab fa-github"></i>
+        </a>
     </div>
 {% endmacro %}
 
 {% block content %}
     <main class="page">
         {#
-         # The opening states what the report is and how much of it there is: the same figures that
-         # used to close the page, on the brand ground, next to the mark it is stamped with.
+         # The screen opens on the figure rather than on the wordmark - the mark and the name are in the
+         # band above, and saying them again is a screen introducing itself instead of saying something.
+         # Which leaves the page without a visible heading, so it carries one for everything that reads
+         # a document rather than looks at it.
          #}
+        <h1 class="visually-hidden">
+            Complexity Report - how the cyclomatic complexity of PHP open source software evolved over time
+        </h1>
+
         <header class="hero">
-            <div class="wrap hero__inner">
-                <div class="hero__intro">
-                    <div class="logo logo--hero">
-                        <div class="logo__kicker">Open Source PHP Software</div>
-                        <h1 class="logo__title">Complexity Report</h1>
-                    </div>
-                    <p class="hero__subline">
-                        How the cyclomatic complexity of PHP open source software evolved over time - one line
-                        per release, measured with
-                        <a href="https://github.com/sebastianbergmann/phploc" target="_blank" rel="noreferrer">phploc</a>.
-                    </p>
-                    <dl class="stats stats--hero">
-                        <div>
-                            <dt class="stats__label">Repositories</dt>
-                            <dd class="stats__value">{{ statistics.repositoryCount|number_format }}</dd>
-                        </div>
-                        <div>
-                            <dt class="stats__label">Releases</dt>
-                            <dd class="stats__value">{{ statistics.tagCount|number_format }}</dd>
-                        </div>
-                        <div>
-                            <dt class="stats__label">Lines of code</dt>
-                            <dd class="stats__value">{{ statistics.linesOfCode|number_format }}</dd>
-                        </div>
-                    </dl>
-                </div>
+            {% if hasData %}
                 {#
-                 # The report in one number: what the average complexity of everything it tracks did
-                 # within the chosen time frame. All four are rendered, so switching one on is a matter
-                 # of hiding the others - without javascript the year to date figure is the one that
-                 # stands. Nothing measured yet means nothing to roll up, and the mark closes the row
-                 # like it did before.
+                 # The whole report in one number, over the line it took to get there. All four time
+                 # frames are rendered, so picking one hides the others - without javascript the year to
+                 # date figure is the one that stands, and the line under it is the one it was measured
+                 # from.
                  #}
-                {% if hasData %}
-                    <div class="hero-trend" {{ stimulus_controller('trend') }}>
-                        <div class="hero-trend__label">Average complexity</div>
-                        {% for trend in trends %}
-                            <div class="hero-trend__figure" role="tabpanel" id="trend-{{ trend.window.value }}"
-                                 aria-labelledby="trend-tab-{{ trend.window.value }}"
-                                 data-trend-target="panel" {{ not loop.first ? 'hidden' }}>
-                                {% if trend.hasData %}
-                                    <div class="hero-trend__value hero-trend__value--{{ trend.change|trend_tone }}">
-                                        {{ trend.change|signed_percent }}
-                                    </div>
-                                    <p class="hero-trend__caption">
-                                        Ø {{ trend.from|number_format(2) }} → {{ trend.to|number_format(2) }}
-                                        across {{ trend.repositoryCount|number_format }}
-                                        {{ trend.repositoryCount == 1 ? 'library' : 'libraries' }}
-                                        <span class="hero-trend__since">
-                                            {{ trend.since ? 'since %s'|format(trend.since|date('F j, Y')) : 'since their own first release' }}
-                                        </span>
-                                    </p>
-                                {% else %}
-                                    <div class="hero-trend__value hero-trend__value--flat">–</div>
-                                    <p class="hero-trend__caption">
-                                        Nothing was measured before this time frame opened.
-                                    </p>
-                                {% endif %}
-                            </div>
-                        {% endfor %}
-                        <div class="hero-trend__windows" role="tablist" aria-label="Time frame">
+                <div class="wrap hero__inner" {{ stimulus_controller('trend') }}
+                     data-trend-series-value="{{ trends|map(trend => {
+                         window: trend.window.value,
+                         points: trend.series|map(point => {x: point.at|date('Y-m-d'), y: point.complexity}),
+                     })|json_encode|e('html_attr') }}">
+                    <div class="hero__top">
+                        <div class="hero__reading">
                             {% for trend in trends %}
-                                <button type="button" class="hero-trend__window" role="tab"
+                                <div class="hero__panel" role="tabpanel" id="trend-{{ trend.window.value }}"
+                                     aria-labelledby="trend-tab-{{ trend.window.value }}"
+                                     data-trend-target="panel" {{ not loop.first ? 'hidden' }}>
+                                    <div class="hero__label">Average complexity · {{ trend.window.title|lower }}</div>
+                                    {% if trend.hasData %}
+                                        <div class="hero__numbers">
+                                            <div class="hero__value hero__value--{{ trend.change|trend_tone }}">
+                                                {{ trend.change|signed_percent(false) }}
+                                            </div>
+                                            <div class="hero__delta">
+                                                Ø {{ trend.from|number_format(2) }} → {{ trend.to|number_format(2) }}
+                                            </div>
+                                        </div>
+                                        {#
+                                         # The figure said as a sentence, which is what makes it a
+                                         # reading rather than a readout: what moved, over what, and out
+                                         # of how much.
+                                         #}
+                                        <p class="hero__subline">
+                                            PHP open source {{ trend.movement }} {{ trend.window.phrase }} -
+                                            across {{ trend.repositoryCount|number_format }}
+                                            {{ trend.repositoryCount == 1 ? 'library' : 'libraries' }} and
+                                            {{ statistics.tagCount|number_format }} analysed releases, measured with
+                                            <a href="https://github.com/sebastianbergmann/phploc" target="_blank" rel="noreferrer">phploc</a>.
+                                        </p>
+                                    {% else %}
+                                        <div class="hero__numbers">
+                                            <div class="hero__value hero__value--flat">–</div>
+                                        </div>
+                                        <p class="hero__subline">
+                                            Nothing was measured before this time frame opened.
+                                        </p>
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                        </div>
+                        <div class="hero__windows" role="tablist" aria-label="Time frame">
+                            {% for trend in trends %}
+                                <button type="button" class="hero__window" role="tab"
                                         id="trend-tab-{{ trend.window.value }}"
                                         aria-controls="trend-{{ trend.window.value }}"
                                         aria-selected="{{ loop.first ? 'true' : 'false' }}"
@@ -180,54 +140,46 @@
                             {% endfor %}
                         </div>
                     </div>
-                {% else %}
-                    {{ include('mark.html.twig', {size: 168, ground: false, class: 'hero__mark'}) }}
-                {% endif %}
-            </div>
-        </header>
-
-        <div class="band">
-            <div class="wrap submit-band">
-                {#
-                 # The label announces the box before it is reached, the hint keeps reading under it:
-                 # what may be typed in only matters once the box is there.
-                 #}
-                <div class="eyebrow submit-band__label">Find or add a repository</div>
-                {#
-                 # One box for both jobs. Picking a suggestion opens that repository, and anything the
-                 # report does not carry yet is posted to `submit`, which queues it and opens its page.
-                 # Without javascript the form still posts whatever was typed, which is what it did
-                 # before the suggestions existed.
-                 #}
-                <form action="{{ path('submit') }}" method="post" class="submit-form"
-                      {{ stimulus_controller('search', { url: path('search') }) }}>
-                    <input type="hidden" name="_token" value="{{ csrf_token('submit') }}"
-                           data-controller="csrf-protection">
-                    <div class="combobox">
-                        <input type="text" name="repository" class="field field--lg" required
-                               placeholder="Search the report, or paste owner/repository"
-                               aria-label="Search or add a GitHub repository"
-                               autocomplete="off" autocapitalize="off" spellcheck="false"
-                               role="combobox" aria-expanded="false" aria-autocomplete="list"
-                               aria-controls="search-suggestions"
-                               data-search-target="input"
-                               data-action="input->search#query keydown->search#navigate focus->search#query blur->search#close">
-                        <ul class="combobox__menu" id="search-suggestions" role="listbox"
-                            aria-label="Repositories" data-search-target="menu" hidden></ul>
+                    {#
+                     # The same figure between its two ends. It is decoration for anything that cannot
+                     # see it - the sentence above says what it does - so it is hidden from the reading
+                     # order rather than described twice.
+                     #}
+                    <div class="hero__chart" aria-hidden="true">
+                        <canvas data-trend-target="canvas"></canvas>
                     </div>
-                    <button type="submit" class="btn btn--lg">Add repository</button>
-                </form>
-                {% for label, messages in app.flashes(['success', 'danger']) %}
-                    {% for message in messages %}
-                        <div class="alert alert--{{ label }}">{{ message }}</div>
-                    {% endfor %}
-                {% endfor %}
-                <p class="submit-band__hint">
-                    Everything the report carries, plus every public repository on GitHub that is mostly
-                    written in PHP - a composer.json is not needed.
-                </p>
-            </div>
-        </div>
+                    <dl class="hero__stats">
+                        <div class="hero__stat">
+                            <dt class="hero__stat-label">Repositories</dt>
+                            <dd class="hero__stat-value">{{ statistics.repositoryCount|number_format }}</dd>
+                        </div>
+                        <div class="hero__stat">
+                            <dt class="hero__stat-label">Releases</dt>
+                            <dd class="hero__stat-value">{{ statistics.tagCount|number_format }}</dd>
+                        </div>
+                        <div class="hero__stat">
+                            <dt class="hero__stat-label">Lines of code</dt>
+                            <dd class="hero__stat-value">{{ statistics.linesOfCode|number_format }}</dd>
+                        </div>
+                        <div class="hero__stat">
+                            <dt class="hero__stat-label">Vendors</dt>
+                            <dd class="hero__stat-value">{{ statistics.organizationCount|number_format }}</dd>
+                        </div>
+                    </dl>
+                </div>
+            {% else %}
+                {# nothing measured yet is nothing to open on, so the mark stands in for the figure #}
+                <div class="wrap hero__inner hero__inner--empty">
+                    {{ include('mark.html.twig', {size: 120, ground: false, class: 'hero__mark'}) }}
+                    <p class="hero__subline">
+                        How the cyclomatic complexity of PHP open source software evolved over time - one
+                        line per release, measured with
+                        <a href="https://github.com/sebastianbergmann/phploc" target="_blank" rel="noreferrer">phploc</a>.
+                        Nothing is measured yet: the box above takes the first repository.
+                    </p>
+                </div>
+            {% endif %}
+        </header>
 
         <div class="wrap page__body">
             <section {{ stimulus_controller('rankings') }}>
@@ -236,6 +188,20 @@
                         <div class="eyebrow">Rankings</div>
                         <h2 data-rankings-target="title">{{ rankings|first.ranking.title }}</h2>
                     </div>
+                    {#
+                     # The chart opens on what is being read, so the link belongs to the ranking rather
+                     # than to the section: it is one button, and the tab it belongs to is what it draws.
+                     # A ranking that came out empty has nothing to draw, and the button says so by not
+                     # being there.
+                     #}
+                    {% if hasData and rankings|first.repositories is not empty %}
+                        <a class="btn" data-rankings-target="chart"
+                           href="{{ path('chart', {'repositories': rankings|first.repositories|map(ranked => ranked.repository.name)|join(',')}) }}">
+                            {{ rankings|first.repositories|length == 1
+                                ? 'Draw this one in the chart'
+                                : 'Draw these %d in the chart'|format(rankings|first.repositories|length) }}
+                        </a>
+                    {% endif %}
                 </div>
 
                 {% if hasData %}
@@ -245,6 +211,10 @@
                                     aria-controls="ranking-{{ entry.ranking.value }}"
                                     aria-selected="{{ loop.first ? 'true' : 'false' }}"
                                     data-rankings-target="tab" data-title="{{ entry.ranking.title }}"
+                                    data-chart-url="{{ entry.repositories is empty ? '' : path('chart', {'repositories': entry.repositories|map(ranked => ranked.repository.name)|join(',')}) }}"
+                                    data-chart-label="{{ entry.repositories|length == 1
+                                        ? 'Draw this one in the chart'
+                                        : 'Draw these %d in the chart'|format(entry.repositories|length) }}"
                                     data-action="rankings#select">
                                 {{ entry.ranking.label }}
                                 {% if entry.ranking.hint %}
@@ -259,135 +229,91 @@
                              aria-labelledby="tab-{{ entry.ranking.value }}"
                              data-rankings-target="panel" {{ not loop.first ? 'hidden' }}>
                             {#
-                             # The chart opens on what is being read, so the link belongs to the ranking
-                             # rather than to the section above it: every panel carries its own, drawn
-                             # with its own top repositories, and only the visible one can be clicked.
-                             #}
-                            <div class="ranking__intro">
-                                <p class="ranking__caption">{{ entry.ranking.caption }}</p>
-                                {% if entry.repositories is not empty %}
-                                    <a class="btn btn--secondary ranking__chart"
-                                       href="{{ path('chart', {'repositories': entry.repositories|map(ranked => ranked.repository.name)|join(',')}) }}">
-                                        Open the chart
-                                    </a>
-                                {% endif %}
-                            </div>
-                            {#
                              # A ranking can come out empty although the report has data - nothing
                              # increased within the last twelve months is a result, not a broken page.
                              #}
                             {% if entry.repositories is empty %}
                                 <p class="empty-state">Nothing the report carries got more complex within the last 12 months.</p>
                             {% else %}
-                                <div class="repo-grid">
+                                <div class="ranking-table ranking-table--{{ entry.ranking.value }}">
+                                    <div class="ranking-table__head">
+                                        <span>#</span>
+                                        <span>Repository</span>
+                                        {% for column in entry.ranking.columns %}
+                                            <span class="ranking-table__number">{{ column.label }}</span>
+                                        {% endfor %}
+                                        <span></span>
+                                    </div>
                                     {% for ranked in entry.repositories %}
-                                        {{ _self.card(ranked, entry.ranking.value, loop.index) }}
+                                        {{ _self.row(ranked, entry.ranking, loop.index) }}
                                     {% endfor %}
                                 </div>
+                                <p class="ranking__caption">
+                                    {{ entry.ranking.caption }} {{ entry.ranking.legend }}
+                                </p>
                             {% endif %}
                         </div>
                     {% endfor %}
                 {% else %}
-                    <p class="empty-state">Nothing analysed yet - submit the first repository above.</p>
+                    <p class="empty-state">Nothing analysed yet - the box above takes the first repository.</p>
                 {% endif %}
             </section>
-        </div>
-
-        {#
-         # What those numbers mean and where they come from, right after the first screen full of them
-         # and before the two quiet lists that close the page.
-         #}
-        {{ include('about.html.twig') }}
-
-        <div class="wrap page__body">
-            {#
-             # The GitHub accounts behind the repositories are a lens on the same list, not a place of
-             # their own: every one of them opens the chart with what was submitted for it. Which is
-             # why only accounts with more than one repository are listed - a single one is a link to
-             # that repository under another name.
-             #}
-            {% if vendors is not empty %}
-                <div class="vendors">
-                    <div class="eyebrow vendors__label">By vendor</div>
-                    {#
-                     # The dark half of a vendor pill is how much of the report it accounts for, which is
-                     # what they are ordered by - so the row reads as a ranking of its own.
-                     #}
-                    <div class="pill-row">
-                        {% for vendor in vendors %}
-                            {{ _self.pill(
-                                vendor.login,
-                                vendor.count,
-                                path('chart', {'repositories': vendor.repositories|join(',')}),
-                                '%d measured repositories of %s'|format(vendor.count, vendor.login)
-                            ) }}
-                        {% endfor %}
-                    </div>
-                </div>
-            {% endif %}
 
             {#
              # What came in last, in the two ways something can: a repository somebody submitted, and a
-             # release a worker measured. The left column is the one place a repository shows up the day
-             # it was added, since the rankings only carry what has numbers - a pill says where its
-             # analysis stands as long as there is something to say about it. The right column is the
-             # other end of the same work: a repository is added once, its releases keep arriving, and a
-             # nightly scan adds them without anyone submitting anything.
+             # release a worker measured. They used to be two lists in a section of their own; read next
+             # to each other they are one line, and the accounts behind the repositories hang off its
+             # end - a lens on the same repositories, not a place of their own, so it is folded away
+             # until somebody wants it.
              #}
-            {% if latest is not empty or latestReleases is not empty %}
-                <section class="section">
-                    <div class="section-header">
-                        <div>
-                            <div class="eyebrow">Recently added</div>
-                            <h2>Latest additions</h2>
+            {% if activity is not empty or vendors is not empty %}
+                <div class="just-in" {{ stimulus_controller('disclosure') }}>
+                    {% if activity is not empty %}
+                        <span class="eyebrow just-in__label">Just in</span>
+                        <div class="pill-row">
+                            {% for entry in activity %}
+                                <a class="pill" href="{{ path('chart', {'repositories': entry.repository}) }}"
+                                   title="{{ entry.title }}">
+                                    <span class="pill__name">{{ entry.repository }}</span>
+                                    <span class="pill__value{{ entry.state ? ' pill__value--state' }}">{{ entry.value }}</span>
+                                </a>
+                            {% endfor %}
                         </div>
-                    </div>
-                    <div class="latest">
+                    {% endif %}
+                    {% if vendors is not empty %}
                         {#
-                         # The dark half of a library pill is where its analysis stands, so a pill
-                         # that is only its name is one that has its numbers - which is the majority,
-                         # and the reason the state is what gets marked rather than the other way round.
+                         # Rendered without the button and with the row open: folding it away is what
+                         # the controller does, so a browser that does not run it keeps the vendors.
                          #}
-                        {% if latest is not empty %}
-                            <div class="latest__column">
-                                <div class="eyebrow latest__label">Libraries</div>
-                                <div class="pill-row">
-                                    {% for repository in latest %}
-                                        {{ _self.pill(
-                                            repository.name,
-                                            repository.isAnalysed ? null : (repository.hasData ? 'analysing' : 'queued'),
-                                            path('chart', {'repositories': repository.name}),
-                                            repository.isAnalysed
-                                                ? '%s, submitted %s'|format(repository.name, repository.submitted|date('F j, Y'))
-                                                : '%s is waiting for a worker'|format(repository.name),
-                                            true
-                                        ) }}
-                                    {% endfor %}
-                                </div>
-                            </div>
-                        {% endif %}
+                        <button type="button" class="just-in__more" aria-expanded="true" hidden
+                                aria-controls="vendor-list" data-disclosure-target="toggle"
+                                data-action="disclosure#toggle">
+                            {{ vendors|length }} {{ vendors|length == 1 ? 'vendor' : 'vendors' }}
+                        </button>
                         {#
-                         # A release pill is the repository and the version measured for it, and opens
-                         # the chart of that repository - which is where the release is a point.
+                         # The dark half of a vendor pill is how much of the report it accounts for,
+                         # which is what they are ordered by - so the row reads as a ranking of its own.
                          #}
-                        {% if latestReleases is not empty %}
-                            <div class="latest__column">
-                                <div class="eyebrow latest__label">Releases</div>
-                                <div class="pill-row">
-                                    {% for tag in latestReleases %}
-                                        {{ _self.pill(
-                                            tag.repository.name,
-                                            tag.name,
-                                            path('chart', {'repositories': tag.repository.name}),
-                                            '%s %s, tagged %s'|format(tag.repository.name, tag.name, tag.created|date('F j, Y'))
-                                        ) }}
-                                    {% endfor %}
-                                </div>
+                        <div class="just-in__vendors" id="vendor-list" data-disclosure-target="panel">
+                            <div class="pill-row">
+                                {% for vendor in vendors %}
+                                    <a class="pill" title="{{ '%d measured repositories of %s'|format(vendor.count, vendor.login) }}"
+                                       href="{{ path('chart', {'repositories': vendor.repositories|join(',')}) }}">
+                                        <span class="pill__name">{{ vendor.login }}</span>
+                                        <span class="pill__value">{{ vendor.count }}</span>
+                                    </a>
+                                {% endfor %}
                             </div>
-                        {% endif %}
-                    </div>
-                </section>
+                        </div>
+                    {% endif %}
+                </div>
             {% endif %}
         </div>
     </main>
+
+    {#
+     # What those numbers mean closes the screen, directly above the credits - the two are read as one
+     # band. The chart does not carry it anymore: it is read once, where the report is read at a glance.
+     #}
+    {{ include('about.html.twig') }}
 {% endblock %}

--- a/tests/ComplexityReport/ActivityTest.php
+++ b/tests/ComplexityReport/ActivityTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\ComplexityReport;
+
+use App\ComplexityReport\Activity;
+use App\ComplexityReport\Analysis;
+use App\ComplexityReport\GitTag;
+use App\Entity\Organization;
+use App\Entity\Repository;
+use App\Entity\Tag;
+use PHPUnit\Framework\TestCase;
+
+final class ActivityTest extends TestCase
+{
+    public function testWaitingRepositoriesComeFirstAndReleasesFillWhatIsLeft(): void
+    {
+        $feed = Activity::feed(
+            [self::queued('symfony/uid'), self::analysed('symfony/console')],
+            [self::release('laravel/framework', 'v11.9'), self::release('guzzle/guzzle', '7.9')],
+            8,
+        );
+
+        self::assertSame(
+            ['symfony/uid', 'laravel/framework', 'guzzle/guzzle'],
+            array_map(static fn (Activity $entry) => $entry->repository, $feed),
+        );
+        self::assertSame(['queued', 'v11.9', '7.9'], array_map(static fn (Activity $entry) => $entry->value, $feed));
+        self::assertSame([true, false, false], array_map(static fn (Activity $entry) => $entry->state, $feed));
+    }
+
+    /**
+     * A repository that is measured has nothing outstanding - what it did is the releases below it.
+     */
+    public function testARepositoryThatIsThroughIsNotOnTheStrip(): void
+    {
+        $feed = Activity::feed([self::analysed('symfony/console')], [], 8);
+
+        self::assertSame([], $feed);
+    }
+
+    public function testARepositoryWithItsFirstReleasesInIsBeingAnalysed(): void
+    {
+        $feed = Activity::feed([self::measured('symfony/uid')], [], 8);
+
+        self::assertSame('analysing', $feed[0]->value);
+        self::assertTrue($feed[0]->state);
+    }
+
+    /**
+     * A worker measures a repository release by release, so the newest releases the report has are
+     * usually all of the same one. The strip is what came in, not how often it came in.
+     */
+    public function testARepositoryIsNamedOnce(): void
+    {
+        $feed = Activity::feed(
+            [],
+            [self::release('symfony/symfony', 'v7.2'), self::release('symfony/symfony', 'v7.1')],
+            8,
+        );
+
+        self::assertCount(1, $feed);
+        self::assertSame('v7.2', $feed[0]->value);
+    }
+
+    /**
+     * A repository whose first releases just arrived would otherwise stand on the strip twice, saying
+     * two different things about itself.
+     */
+    public function testAReleaseOfSomethingStillWaitingDoesNotRepeatIt(): void
+    {
+        $waiting = self::measured('symfony/uid');
+
+        $feed = Activity::feed([$waiting], [self::release('symfony/uid', '7.3')], 8);
+
+        self::assertCount(1, $feed);
+        self::assertSame('analysing', $feed[0]->value);
+    }
+
+    public function testItStopsAtTheLimit(): void
+    {
+        $releases = array_map(
+            static fn (int $index) => self::release(sprintf('vendor/repository-%d', $index), '1.0'),
+            range(1, 12),
+        );
+
+        self::assertCount(3, Activity::feed([], $releases, 3));
+    }
+
+    /**
+     * The limit bounds the strip, not what is still owed an answer: a report with more repositories
+     * waiting than the strip has room for says so rather than showing releases instead.
+     */
+    public function testWaitingRepositoriesAreNotCrowdedOutByReleases(): void
+    {
+        $feed = Activity::feed(
+            [self::queued('a/one'), self::queued('a/two'), self::queued('a/three')],
+            [self::release('b/measured', '1.0')],
+            2,
+        );
+
+        self::assertSame(['a/one', 'a/two'], array_map(static fn (Activity $entry) => $entry->repository, $feed));
+    }
+
+    private static function queued(string $name): Repository
+    {
+        return new Repository(
+            $name,
+            sprintf('https://github.com/%s', $name),
+            sprintf('https://github.com/%s.git', $name),
+            new Organization(strstr($name, '/', true) ?: $name),
+        );
+    }
+
+    private static function measured(string $name): Repository
+    {
+        $repository = self::queued($name);
+        $repository->addTag(new GitTag('1.0'), new Analysis(100, 2.0, new \DateTimeImmutable('2020-01-01'), []));
+
+        return $repository;
+    }
+
+    private static function analysed(string $name): Repository
+    {
+        $repository = self::measured($name);
+        $repository->markAnalysed();
+
+        return $repository;
+    }
+
+    private static function release(string $repository, string $name): Tag
+    {
+        return new Tag($name, new \DateTimeImmutable('2024-11-29'), 100, 2.0, self::queued($repository), []);
+    }
+}

--- a/tests/ComplexityReport/ChartSelectionTest.php
+++ b/tests/ComplexityReport/ChartSelectionTest.php
@@ -106,6 +106,25 @@ final class ChartSelectionTest extends TestCase
     }
 
     /**
+     * What the strip under the chart says it is drawn from. A repository still waiting for a worker is
+     * not a line, so it brings no releases to the count either.
+     */
+    public function testItCountsTheReleasesOfEveryLineItDraws(): void
+    {
+        $console = self::analysed('symfony/console');
+        $console->addTag(new GitTag('1.1'), new Analysis(120, 2.1, new \DateTimeImmutable('2021-01-01'), []));
+
+        $selection = ChartSelection::of([$console, self::repository('symfony/uid')], [$console]);
+
+        self::assertSame(2, $selection->getReleaseCount());
+    }
+
+    public function testAChartWithoutALineCountsNothing(): void
+    {
+        self::assertSame(0, ChartSelection::mostStarred([], 8)->getReleaseCount());
+    }
+
+    /**
      * A repository that was submitted and is waiting for its first release.
      */
     private static function repository(string $name, ?Organization $organization = null): Repository

--- a/tests/ComplexityReport/RankingTest.php
+++ b/tests/ComplexityReport/RankingTest.php
@@ -56,6 +56,33 @@ final class RankingTest extends TestCase
             self::assertNotSame('', $ranking->label());
             self::assertNotSame('', $ranking->title());
             self::assertNotSame('', $ranking->caption());
+            self::assertNotSame('', $ranking->legend());
+        }
+    }
+
+    /**
+     * The table is one grid whatever tab is on, so every ranking fills the same three columns - and
+     * whatever it sorts by is the one right of the name, so the order the rows are in is readable off
+     * the rows themselves.
+     */
+    public function testEveryRankingLeadsWithWhatItSortsBy(): void
+    {
+        $leads = [
+            Ranking::Stars->value => 'stars',
+            Ranking::Complexity->value => 'complexity',
+            Ranking::Size->value => 'loc',
+            Ranking::Growth->value => 'growth',
+        ];
+
+        foreach (Ranking::all() as $ranking) {
+            $columns = $ranking->columns();
+
+            self::assertCount(3, $columns, $ranking->value);
+            self::assertSame($leads[$ranking->value], $columns[0]['key']);
+
+            foreach ($columns as $column) {
+                self::assertNotSame('', $column['label']);
+            }
         }
     }
 

--- a/tests/ComplexityReport/Trend/TrendCalculatorTest.php
+++ b/tests/ComplexityReport/Trend/TrendCalculatorTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\ComplexityReport\Trend;
 use App\ComplexityReport\Trend\ReleasePoint;
 use App\ComplexityReport\Trend\Trend;
 use App\ComplexityReport\Trend\TrendCalculator;
+use App\ComplexityReport\Trend\TrendPoint;
 use App\ComplexityReport\Trend\TrendWindow;
 use PHPUnit\Framework\TestCase;
 
@@ -167,6 +168,71 @@ final class TrendCalculatorTest extends TestCase
         foreach ($trends as $trend) {
             self::assertFalse($trend->hasData());
         }
+    }
+
+    /**
+     * The line in the hero is the same statement as the figure over it, so it has to start and end
+     * where the figure does - anything else is a chart disagreeing with the number next to it.
+     *
+     * All time is the exception it is everywhere else: there a library is compared against its own
+     * first release rather than against a date they share, so the line opens on whichever of them was
+     * measured first instead of on the mean of all their first releases.
+     *
+     * @dataProvider windows
+     */
+    public function testTheSeriesRunsFromTheFigureToTheFigure(TrendWindow $window, float $from, float $to): void
+    {
+        $series = $this->calculate($window, self::report())->series;
+
+        self::assertNotEmpty($series);
+        self::assertSame($to, end($series)->complexity);
+
+        if (TrendWindow::AllTime !== $window) {
+            self::assertSame($from, $series[0]->complexity);
+        }
+    }
+
+    public function testTheSeriesSpansTheWindowAndEndsNow(): void
+    {
+        $series = $this->calculate(TrendWindow::FiveYears, self::report())->series;
+
+        self::assertNotEmpty($series);
+        self::assertSame('2021-07-31', $series[0]->at->format('Y-m-d'));
+        self::assertSame('2026-07-31', end($series)->at->format('Y-m-d'));
+    }
+
+    /**
+     * All time has no date the libraries share, so it opens where the oldest of them was first
+     * measured - which makes it the one window whose line is the dataset growing as much as it is the
+     * code changing. The others compare a set that does not change across the whole line.
+     */
+    public function testAllTimeStartsAtTheOldestReleaseTheReportCarries(): void
+    {
+        $series = $this->calculate(TrendWindow::AllTime, self::report())->series;
+
+        self::assertSame('2018-01-01', $series[0]->at->format('Y-m-d'));
+        // only `1` had been measured by then, at 10.0
+        self::assertSame(10.0, $series[0]->complexity);
+    }
+
+    public function testTheSeriesIsSampledInAscendingOrder(): void
+    {
+        $series = $this->calculate(TrendWindow::AllTime, self::report())->series;
+        $dates = array_map(static fn (TrendPoint $point) => $point->at->getTimestamp(), $series);
+        $sorted = $dates;
+
+        sort($sorted);
+
+        self::assertGreaterThan(2, \count($series));
+        self::assertSame($sorted, $dates);
+    }
+
+    public function testTheSeriesDoesNotCareInWhichOrderTheReleasesArrive(): void
+    {
+        self::assertEquals(
+            $this->calculate(TrendWindow::FiveYears, self::report())->series,
+            $this->calculate(TrendWindow::FiveYears, array_reverse(self::report()))->series
+        );
     }
 
     /**

--- a/tests/ComplexityReport/Trend/TrendTest.php
+++ b/tests/ComplexityReport/Trend/TrendTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\ComplexityReport\Trend;
+
+use App\ComplexityReport\Trend\Trend;
+use App\ComplexityReport\Trend\TrendWindow;
+use PHPUnit\Framework\TestCase;
+
+final class TrendTest extends TestCase
+{
+    /**
+     * @dataProvider movements
+     */
+    public function testItSaysWhatTheFigureDidRatherThanRepeatingIt(float $change, string $expected): void
+    {
+        self::assertSame($expected, self::trend($change)->movement());
+    }
+
+    /**
+     * @return iterable<string, array{float, string}>
+     */
+    public static function movements(): iterable
+    {
+        // the threshold the report colours a change by - what is printed grey is not a direction
+        yield 'nothing worth a direction' => [0.0, 'held steady'];
+        yield 'below a twentieth of a percent' => [0.04, 'held steady'];
+        yield 'just above it' => [-0.06, 'got slightly less branchy'];
+        yield 'slightly simpler' => [-1.8, 'got slightly less branchy'];
+        yield 'slightly hairier' => [1.9, 'got slightly more branchy'];
+        yield 'simpler' => [-6.4, 'got less branchy'];
+        yield 'hairier' => [9.9, 'got more branchy'];
+        yield 'much simpler' => [-14.2, 'got much less branchy'];
+        yield 'much hairier' => [22.9, 'got much more branchy'];
+    }
+
+    /**
+     * A window nothing reaches back to has no direction either - and it never says "held steady",
+     * because holding steady is something a report with data did.
+     */
+    public function testAWindowWithoutDataCarriesNoSeries(): void
+    {
+        $trend = Trend::withoutData(TrendWindow::YearToDate);
+
+        self::assertFalse($trend->hasData());
+        self::assertSame([], $trend->series);
+    }
+
+    private static function trend(float $change): Trend
+    {
+        return new Trend(TrendWindow::YearToDate, 2.34, 2.30, $change, 64);
+    }
+}


### PR DESCRIPTION
Implements direction 1a of the Claude Design handoff: the report reads as one argument rather than as a page of boxes.

Start page
- The hero opens on the figure instead of on the wordmark: the trend as a number, the sentence it makes, the line it took to get there, and the size of the dataset under it. `TrendCalculator` gains that line - the same mean it computes at the two ends of a window, sampled between them, so the chart and the number next to it agree. `Trend::movement()` says the figure in words rather than repeating it.
- The rankings become one table instead of nine cards. Whatever a tab sorts by is the column right of the name (`Ranking::columns()`), and what those columns hold is spelled out under it (`Ranking::legend()`).
- Vendors and the two "latest additions" lists collapse into one strip: waiting repositories first, then the newest releases, one entry per repository (`Activity`). The accounts hang off its end, folded away.
- The about block says the short version; every caveat is still there, behind the sentence introducing it.

Chart page
- Everything about the chart moves into its panel: the lines it draws as chips on the top edge, what it draws them as next to those, and what it is made of on the bottom one. The chips are the legend now, so the chart.js one is gone and the canvas keeps that height.
- The release analysis leads with the four figures a release comes down to, then three groups instead of four - what it did against the release before it is one of the figures.
- The screen headline is gone; the document is still named after what is in the chart, and the way out to github.com moved onto the release rail.

Both
- The search box moves into the header band, where every screen can reach it, and answers `/`. The submit band it stood in is gone; what a submission is answered with stands directly under the box, and is only read when a session cookie says there can be one.


Claude-Session: https://claude.ai/code/session_0161YDTRvxeEsriJdfWAZjRB