### PR TITLE
Read every number phploc counts, not the two the report was built on

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,9 @@ yarn check-style    # prettier over assets/
 ```
 
 Tests live under `App\Tests\` (PSR-4 → `tests/`) and cover the pure domain logic (input parsing, API
-mapping, release detection, the rolled up trends, the raw output printed from a measurement) — everything
-else needs a booted kernel and is not covered yet.
+mapping, release detection, the rolled up trends, the raw output printed from a measurement, and the metric
+catalog — including that every metric still names a key phploc counts, checked against a measurement taken
+in the test) — everything else needs a booted kernel and is not covered yet.
 
 ## Rebuilding the dataset
 
@@ -118,7 +119,11 @@ refreshes): `Organization` (a GitHub account,
 e.g. `symfony`) → `Repository` (a GitHub repository, e.g. `symfony/console`, holds `stars` + `analysed`) →
 `Tag` (one analysed release, holds `linesOfCode` + `averageComplexity` + `created`, plus `metrics`: the
 whole phploc measurement those two are read out of, which every release carries — the column was nullable
-while the releases measured before it existed were being re-measured, and is not anymore).
+while the releases measured before it existed were being re-measured, and is not anymore). The two columns
+stay columns because the report is sorted, ranked and trended by them in SQL; the other sixty are read out
+of the json through `Metric/*` and never ordered by, which is why they are not columns and why nothing
+here is `jsonb` yet — the day a ranking wants "every repository by static method calls" is the day that
+changes.
 `Organization` is not
 a screen of its own anymore, only the account a repository is grouped under, and it holds nothing but the
 GitHub `login` it is addressed by plus an avatar: the display name and homepage it used to carry came from
@@ -191,6 +196,22 @@ with their phploc measurements.
 - `PhplocReport` — a stored measurement printed the way the phploc command line prints it, by handing it to
   phploc's own `Log\Text`. There is no second layout to keep in step with the tool, which is why the modal
   can be called raw output; the printer writes to standard output, so this catches it in a buffer.
+- `Metric/*` — the blob read out. `Metric` is the catalog: **54 of the 62 numbers** phploc counts, each
+  addressed by a slug (`?metrics=complexity,loc`) rather than by the phploc key behind it (`source()`,
+  `classCcnAvg`), since the query string is a link people read — plus its `label()`, one line of `about()`,
+  the `MetricGroup` phploc prints it under, the whole it is `partOf()` (which is what a percentage is read
+  against and what the interpreted measurement indents by), how many `decimals()` it is written and rounded
+  to, its `MetricDirection` (only the complexities have one: a library that grew by twenty thousand lines
+  did not thereby get worse, so only risk is coloured) and whether it `carriesLevel()` — the two *averages*,
+  since the `ComplexityLevel` bands are written for an average and a maximum would paint a library red for
+  one outlier. Left out are the five minimums (`classCcnMin` is 1 in 96% of the twenty thousand releases —
+  a straight line at 1), `testClasses`/`testMethods` (always 0, tests are never counted) and `ccnMethods`;
+  all of them are still in the measurement and still in the raw output. `Measurement` is the reading:
+  `value()` rounded to the metric, `share()` of its whole, `values()` for the numbers a chart line is drawn
+  as, `interpreted()` for the whole catalog at once. `MetricSelection` parses `?metrics=` by the rules the
+  repositories of a chart already follow (order kept, one per metric, unknown dropped, empty is the default)
+  and still reads the `?metric=` of the switch this grew out of. `MetricCatalog` is the whole thing handed
+  to the browser, so nothing about a metric is written down twice.
 - `Git` / `GitController` / `CodeAnalyser` — `Git` shells out via symfony/process and logs every call on the
   `git` monolog channel; it passes arguments as a list (never a shell line), pins `GIT_TERMINAL_PROMPT=0` so
   a repository that went private fails instead of blocking a worker on a credential prompt, and gives every
@@ -243,38 +264,56 @@ an unknown repository, a fork, too little PHP - stays a flash on the start page,
 303 turbo needs, because a human mistyping twice should not get an error page. Anything that gets through
 ends on the page of its repository, whether it was just queued or has been in the report for years.
 
-**Web** (`src/Controller/ReportController`) — two screens: `start` renders the trend in the hero, the
-submit form, the rankings, then the block explaining the report, and below it the two quiet lists that
-close the page - the GitHub vendors (only those grouping more than one measured repository - a single one
-is the repository the rankings already link to), ordered by how many measured repositories they account
-for, and the latest additions, which are two columns because something comes in in two ways:
-`LATEST_LIMIT` repositories newest submission first, measured or not - the rankings only carry what has
-numbers, so this is the one place a repository shows up the day it was added, marked while it is `queued`
-or being analysed - and next to them `LATEST_LIMIT` releases, ordered by `Tag` id, since when a release
-was measured is not stored and the id is the order the rows were written in; a repository is submitted
-once, its releases keep arriving from the nightly scan. All three lists are the same `.pill`: a name on
-light ground joined to the one thing said about it on dark - a count, a state, a version - so what
-differs between them is only what their dark half carries, and nothing surrounds the two halves (`.badge`
-is the single-ground count of the design system, which is a different thing). `chart` is everything
+**Web** (`src/Controller/ReportController`) — two screens: `start` opens on the trend as a figure, then
+the rankings as **one table** rather than nine cards (whatever a tab sorts by is the column right of the
+name, `Ranking::columns()`, and `Ranking::legend()` spells out what those columns hold), and closes on the
+"just in" strip - what came in last in the two ways something can, one entry per repository (`Activity`
+merges `LATEST_LIMIT` submissions with the newest of `ACTIVITY_DEPTH` releases down to `ACTIVITY_LIMIT`
+entries, since a worker measures release by release and the newest releases are otherwise all of the same
+repository). The GitHub vendors hang off the end of that strip, folded away by `disclosure_controller.js`
+- a lens on the same repositories, not a place of their own. Both are the same `.pill`: a name on light
+ground joined to the one thing said about it on dark - a count, a state, a version - so what differs
+between them is only what their dark half carries, and nothing surrounds the two halves (`.badge` is the
+single-ground count of the design system, which is a different thing). The submit box is not a band of
+the start page anymore: it is the **search box in the header**, reachable from every screen and answering
+`/`, and what a submission is answered with stands directly under it. `chart` is everything
 else. There is **one** chart page, not one per organization: `?repositories=symfony/console,nikic/iter`
 says which repositories it draws, in that order, and anything the report carries can be added to them.
 There is **no** cap on how many: a vendor of fifty measured repositories is a chart of fifty, and what
 bounds a query string is the report itself, since it cannot name more repositories than exist -
 `CHART_DEFAULT` is only where a chart *starts* when nobody picked anything, the eight most starred, one
 per colour of the palette. Past the eighth line the palette starts over, and each pass through it is
-stroked differently (`SERIES_DASHES`), so a ninth line shares its colour but not its look; past a full
-palette the chart legend is dropped, because the picker chips above say the same thing in the same
-colours without taking the height the chart is drawn in.
+stroked differently (`SERIES_DASHES`), so a ninth line shares its colour but not its look. There is no
+chart.js legend at all: the chips on the top edge of the panel are the legend - a line per chip in the
+colour it is drawn in, there whether the chart holds five lines or fifty - and a second one under the
+chart would say it twice and take the height the chart is drawn in to do it.
 Repositories are addressed by the slug they carry on github.com, never by a database id - the query string
 is a link people read, edit and share, so it says what it draws. The case does not matter, and slugs that
 are not repositories are dropped rather than answered with an error.
-`?metric=loc` says the lines are drawn as lines of code instead - the switch above the chart
-(`chart_controller.js`, `METRICS`), which is a redraw and not a fetch, since a release is two numbers and
-both are in every graph the page already has. Complexity is what the report is about, so it is what a
-chart opens on and it carries no `metric` at all; only the other one is written into the query string.
-Switching resets the zoom, because a window onto a complexity of four says nothing about a codebase of
-half a million lines. The metric is read in the browser and nowhere else: it decides how the same data is
-drawn, not which data the server has to render.
+`?metrics=complexity,loc` says what the same lines can be read as, by the same rules and in the order they
+were named, and `?metric=loc` says which of them is the one being looked at - the switch this grew out of,
+still meaning what it meant, so the links that were handed out under it still open what they named. A tab
+that is not one of the chart's own is dropped like a repository that is not in the report, and the chart
+opens where it would anyway. Complexity is what the report is about, so it is what a chart opens on and
+that chart carries neither parameter.
+A second metric is a **tab**, not a second axis and not a second chart: colour already says which
+repository a line belongs to and cannot also say which number it is - a chart of fifty repositories in two
+metrics would be a hundred lines - and two scales in one frame let a crossing look like a statement when
+what crossed was the scaling ([Datawrapper](https://www.datawrapper.de/blog/dual-axis-charts-guide),
+[Flourish](https://flourish.studio/blog/dual-axis-charts/) on why; SonarQube's activity page caps a graph
+at three measures for the same reason). Drawn one at a time **in the same frame** - same place, same
+width, same years - two metrics are compared by switching between them, which is a comparison a stack of
+panels below one another makes the reader scroll for. Switching keeps the years the reader is in and drops
+a zoom on the other axis, because that one belonged to the number being read.
+Every metric of a chart therefore travels with every release: switching a tab must be a redraw and never a
+request. Adding one is the fetch - the JSON route takes `?metrics=` too, and a line already on the page is
+asked only for the number it is missing.
+Those tabs live **inside the chart panel**, on the row under the repository chips, and they end on the
+hairline closing the panel head - so whichever one is open underlines the frame it draws in, and the head
+answers the two questions about a chart in the order they are asked: which repositories, and in which
+number. A single metric is still a tab there: with nothing to switch to it is not a choice but a label,
+and it is the only place the chart says what it is drawing. What that number is worth is the sentence on
+the panel foot, in front of the hint about zooming.
 `ChartSelection` is what the template reads: the series, the repositories still waiting for a worker, the
 options of the picker, and what the page is called. The screen is **not** named after the way it was
 reached - it is named after what is in it, by one rule that survives the chart being edited in place: the
@@ -286,10 +325,10 @@ right now - the one state the browser cannot rename, since nothing can be picked
 
 What the report does not say by itself is `templates/about.html.twig`: how a number gets into it, what
 that number is worth, and the scale it is read against. It is not the footer anymore - the footer is the
-credits - but a band each screen places itself, since where it belongs differs: on the start page it
-stands under the rankings and before the lists closing them, on the chart page it ends the screen,
-rendered outside `<main>` so it is the element right before the credits and `.about + .site-footer`
-closes the two into the one band they were.
+credits - but the band closing the **start page**, rendered outside `<main>` so it is the element right
+before them and `.about + .site-footer` closes the two into the one band they were. The chart does not
+carry it: it is read once, where the report is read at a glance. It says the short version, and every
+caveat is still there behind the sentence introducing it (`disclosure_controller.js` again).
 
 The **scale** (`templates/complexity_scale.html.twig`) opens that block, across both columns that explain
 the report rather than inside the one about the metric - it is what every number of the report is read
@@ -298,24 +337,29 @@ It is the four bands of `ComplexityLevel` over the ramp they run through,
 the bands washed white so their ranges stay readable and only the hairlines between them and the strip
 below them carry the colour at full strength. On a phone the ramp turns and the bands stack on it,
 which is the same reading in the direction there is room for. Every complexity elsewhere is marked with a
-dot in the colour of its band - on a card it stands where the `Ø` stood, since a metric leads with one
-glyph and the row has no width to spare, and in the release analysis it leads the numbers that are
-complexities rather than changes to one.
+dot in the colour of its band - in the ranking table it is the complexity column, and in the release
+analysis it leads the numbers that are complexities rather than changes to one. Only the two *averages*
+of the catalog carry it (`Metric::carriesLevel()`): the bands are written for an average, and a maximum
+would paint a library red for one outlier.
 
 Routes are distinguished by `priority`, since `{organization}` and the slug of a repository both match
 whatever is left — and every one of them is **negative**, because routing sorts the whole collection and
 not the controller: a positive priority puts a catch-all in front of what the framework registers, and
 `/_wdt/{token}` and `/_profiler/{token}` are two segments like every repository slug, so the profiler
 answered 404 as a repository nobody submitted. Below zero the report is what is left over, which is what it
-is: `chart`/`search`/`submit` (-1) > `repository` (-2, `owner/repository`, returns one line of
-the chart as JSON - the slug is the whole route, so the select box can request it relative to the page it
-is on) and `raw` (-2, `owner/repository/<tag>/raw`, one release as phploc printed it, `text/plain` and
+is: `chart`/`search`/`submit` (-1) > `repository` (-2, `owner/repository?metrics=…`, returns one line of
+the chart as JSON in the numbers it was asked for - the slug is the whole route, so the select box can
+request it relative to the page it is on), `measurement` (-2, `owner/repository/<tag>/metrics`, one release
+interpreted: every number of the catalog with its share of its whole, plus the release before it so each
+can be read as a change; cacheable for an hour, since a backfill can still put another release in front of
+it) and `raw` (-2, `owner/repository/<tag>/raw`, the same release as phploc printed it, `text/plain` and
 cacheable for a day since a released tag does not get measured differently again; a release the report does
 not carry answers 404) > `organization` (-3). The last one is the page GitHub accounts used to have, kept as a permanent
 redirect into the chart - `?repository=<id>` included, since that is how the links that were handed out
-address a repository. `Repository::asGraph()` returns a `GraphData` value object that JSON-serializes into
-what the chart expects: the releases it draws plus the github.com url and the stars of the repository they
-belong to, so a line picked later carries the same facts as one the page was rendered with.
+address a repository. `Repository::asGraph(metrics)` returns a `GraphData` value object that
+JSON-serializes into what the chart expects: the releases it draws, each with the `values` of the metrics
+asked for, plus the github.com url and the stars of the repository they belong to, so a line picked later
+carries the same facts as one the page was rendered with.
 
 **Frontend** — Vite + symfony/reprise + StimulusBundle. `assets/controllers/chart_controller.js` reads the
 preselected repositories from a `data-repositories` attribute rendered by `templates/chart.html.twig`, and
@@ -324,23 +368,41 @@ picked is written back into the query string, so a chart someone put together is
 analysis below the chart is one tab per line, built from the same graphs: every repository in the chart can
 be read release by release, and a tab carries the colour of its series - and since a point in the chart
 *is* a release, clicking one opens it there: the line it belongs to becomes the tab being read and the
-point the release, scrolled to only when the section is off screen. Its head says what a release is read
-against: the repository it belongs to, linking to github.com and carrying its stars and its first measured
-release, and the day the release was tagged - which is the only date the report has, since when a release
-was measured is whenever it was submitted or a nightly scan found it and says nothing about the code.
-Next to the box that picks the release stands what the report does *not* say about it: phploc counts sixty
-numbers and the report plots two, and the rest is shown as phploc printed it - on the dark ground it was
-printed on (`--terminal-*`, the one dark surface that is not the brand), in a `<dialog>` the panel behind
-it keeps its release through. It is fetched when it is opened rather than carried by the page - a chart
-holds hundreds of releases and this is read one at a time - and kept afterwards, since a measurement does
-not change. Every release carries a measurement, so the button is simply there and `GraphData` says nothing
-about it - it used to carry a `raw` flag per release, for the ones measured before the output was kept.
+point the release, scrolled to only when the section is off screen. Those tabs share one **rail** with
+what is done to the release being read - the way out to github.com, the box picking a release, the raw
+output - because all of them choose what is below.
+Under that rail stand the four figures a release comes down to, and the first three of them are read in
+**whichever metric the chart is open on**: the number itself (carrying the dot of its risk band where the
+metric has one, and named by the band underneath), what it did against the release before it, and what it
+did since the first measured one - so switching a tab above re-reads the release, and the other tabs
+answer the same three questions by being switched to. The fourth is how much of the repository has been
+measured. The date a release carries is the day it was tagged, which is the only date the report has:
+when it was *measured* is whenever it was submitted or a nightly scan found it, and says nothing about the
+code.
+The panel under those figures is the release in the numbers the chart draws - all of the picked metrics,
+not only the one that is drawn, each against the first release - and folded under it stands the rest of
+the measurement: **every number of the catalog**, in phploc's four sections, indented under the whole it
+is a part of, with its share and its change since the previous release, and each name a button that adds
+that metric to the chart and opens its tab, since picking a number out of the measurement means wanting to
+see it. That is the interpreted half; the raw half is on the rail that picks the release,
+the same measurement as phploc printed it - on the dark ground it was printed on (`--terminal-*`, the one
+dark surface that is not the brand), in a `<dialog>` the panel behind it keeps its release through. Both
+are fetched when they are opened rather than carried by the page - a chart holds hundreds of releases and
+this is read one at a time - and kept afterwards, since a measurement does not change. Every release carries
+one, so the buttons are simply there and `GraphData` says nothing about them - it used to carry a `raw` flag
+per release, for the ones measured before the output was kept.
 Turbo caches the page as it is left, so the dialog is closed on
 `turbo:before-cache` - one that came back open would come back not modal, since only `showModal()` puts a
 dialog in the top layer.
 The chart zooms and pans
 (chartjs-plugin-zoom), which the address bar knows nothing about, so the way back is the `.chart-reset`
 button floating over it - rendered `hidden` and shown by the controller only while `isZoomedOrPanned()`.
+Switching a metric goes through `resetZoom()` and then puts the years back with `zoomScale('x', …)`, which
+is also what tells the plugin the chart is still zoomed. What a metric is called, how far its numbers are rounded and
+whether a change in it is worth a colour comes from the catalog rendered into `data-catalog` - `metrics.js`
+only turns a number, or the difference between two, into the element it is read as; the risk bands are the
+one thing it still mirrors from PHP. Chart.js measures an axis before the webfont arrives, so a scale of
+hundreds of thousands comes back too narrow for its own labels: `document.fonts.ready` redraws once.
 `trend_controller.js` switches the time frame of the hero figure, which is rendered for all four windows
 at once, so nothing is fetched when one is picked.
 `refresh_controller.js` reloads the page every 30s while the status above the chart says a repository is
@@ -354,15 +416,34 @@ what is there: a page that comes back open comes back the same, not doubled. `vi
 public path from `ASSET_BASE` (set by the build task in `deploy.php`) rather than the build mode, so local
 production builds keep working.
 
-Both boxes people type in are the **same** control: `assets/combobox.js` is the menu under a field - the
+All three boxes people type in are the **same** control: `assets/combobox.js` is the menu under a field - the
 rows, opening and closing it, and the keyboard that walks it, with what a row says and what picking one
 means left to the box that built it. `search_controller.js` is the one on the start page, which asks the
-server what an input means; `repository_picker_controller.js` is the one above the chart, which has more
+server what an input means and lives in the header band now, where every screen can reach it and `/`
+focuses it; `repository_picker_controller.js` is the one on the top edge of the chart panel, which has more
 than one answer - a chip per line, coloured by its position, which is why a pick moves its option to the
 end of the `<select>` behind it. That select is the state, not a widget: the picker writes to it and
 dispatches its `change`, so the chart is redrawn by one event however a repository got in or out. Only the
 keyboard highlights a row (`.is-active`) - hovering is the pointer's own business, and picking happens on
-`mousedown`, before the blur that closes the menu can race it.
+`mousedown`, before the blur that closes the menu can race it. `assets/dom.js` holds the one line all of
+this is built with (`element()`), which used to live in `combobox.js` and is not about comboboxes.
+
+`metric_picker_controller.js` is the third: the box on the tab row of the chart panel that adds a metric
+to the chart. It is the
+repository box over a list that is already in the page - fifty-four names need typing into, but nothing
+needs to be asked of the server - so it filters the options it was rendered with, over their name, their
+section **and** the sentence the catalog explains them with, since nobody knows what `llocByNof` was called
+before reading what it counts; a row shows all three. Its select is the state for the same reason the
+repositories' is, and the order of the tabs is the order of the selected options - which works because a
+pick is moved to the end of the select, and because the server renders the picked ones first, in the order
+`?metrics=` named them (`MetricSelection::getOptions()`).
+Unlike the repository box it carries **no chips**: what is picked shows up as a tab next to it, and the tab
+row is where a metric is switched to and taken out again - two lists of the same names on the same row
+would be the same statement twice. So the box only ever adds, which is why it is nothing but the dashed
+slot the repository box ends in (`.chart-panel__adder`), and why its menu is the wide one: a row of it
+carries all three parts. The select is written to from three places - the box, a tab's `×`, and the
+measurement table under the chart - so the box listens for its own `change` to keep its menu (what is
+*not* in the chart) true.
 
 **Error reporting** (`config/packages/sentry.yaml`) — sentry/sentry-symfony, registered by hand since
 `allow-contrib` is false and its recipe therefore never ran. `SENTRY_DSN` is empty in the committed `.env`

--- a/assets/combobox.js
+++ b/assets/combobox.js
@@ -6,19 +6,7 @@
  * What a row says and what picking one means stays with the box that built it: this only knows that a
  * row was chosen and by which of the two ways.
  */
-export function element(tag, className, text) {
-    const node = document.createElement(tag);
-
-    if (className) {
-        node.className = className;
-    }
-
-    if (undefined !== text) {
-        node.textContent = text;
-    }
-
-    return node;
-}
+import { element } from './dom.js';
 
 export class Combobox {
     /**

--- a/assets/controllers/chart_controller.js
+++ b/assets/controllers/chart_controller.js
@@ -3,7 +3,8 @@ import Chart from 'chart.js/auto';
 import 'chartjs-adapter-moment';
 import zoomPlugin from 'chartjs-plugin-zoom';
 import moment from 'moment';
-import { element } from '../combobox.js';
+import { element } from '../dom.js';
+import { band, catalogFrom, change, direction, format, group, list, percent, row, share, value } from '../metrics.js';
 
 // The eight series colours of the design system, assigned by position. The swatch in front of every
 // chip in the picker is coloured by the same rule, see _components.scss - which only holds as long as
@@ -25,105 +26,22 @@ const INK = '#101720';
 const MONO = 'IBM Plex Mono';
 const SANS = 'IBM Plex Sans';
 
-const ARROWS = { good: '↓', bad: '↑', flat: '→' };
-
 const count = (value) => value.toLocaleString('en-US');
-const decimal = (value, digits) =>
-    value.toLocaleString('en-US', { minimumFractionDigits: digits, maximumFractionDigits: digits });
-
-/*
- * What the same lines can be drawn as. A release is stored as two numbers and both are in every graph
- * the page already has, so switching between them fetches nothing - `key` is which of them the chart
- * reads out of a release, and the rest is how that number is written wherever it is written out.
- *
- * The report is about complexity, so complexity is what a chart opens on; `name` is what the other one
- * is called in the query string, and the default carries none.
- */
-const METRICS = [
-    { name: 'complexity', key: 'y', label: 'Ø Complexity', short: (value) => `Ø ${decimal(value, 2)}` },
-    { name: 'loc', key: 'loc', label: 'Lines of Code', short: count },
-];
 const day = (value) => moment(value, 'YYYY-MM-DD').format('LL');
 
 // the star count of the rankings, shortened the way the `stars` twig filter shortens it
 const stars = (total) => (total < 1000 ? String(total) : `${(total / 1000).toFixed(1).replace(/\.0$/, '')}k`);
-
-// complexity going down is an improvement, going up is a regression
-const tone = (value) => (Math.abs(value) < 0.005 ? 'flat' : value < 0 ? 'good' : 'bad');
-const sign = (value) => (value > 0 ? '+' : value < 0 ? '−' : '±');
-const signed = (value, digits = 0) => sign(value) + decimal(Math.abs(value), digits);
-const share = (part, total) => (total ? `${decimal((Math.abs(part) / total) * 100, 1)}%` : undefined);
-
-function trend(value, digits, label) {
-    const direction = tone(value);
-    const node = element('span', `trend trend--chip trend--${direction}`);
-
-    node.append(element('span', null, ARROWS[direction]), element('span', null, signed(value, digits)));
-
-    if (label) {
-        node.append(element('span', 'trend__label', label));
-    }
-
-    return node;
-}
-
-/*
- * The risk bands the footer prints, mirrored from `ComplexityLevel` because the release analysis is
- * built here in the browser rather than rendered. Like the naming rule above, the mirror only holds as
- * long as the rule stays this small - four numbers and the band above the last of them.
- */
-const LEVELS = [
-    [10, 'simple', '1–10'],
-    [20, 'moderate', '11–20'],
-    [50, 'complex', '21–50'],
-];
-const UNTESTABLE = ['untestable', '> 50'];
-const level = (value) => LEVELS.find(([limit]) => value <= limit)?.slice(1) ?? UNTESTABLE;
-
-// a measured complexity carrying the dot of its band, the way the rows of the start page carry it
-const complexity = (value) => element('span', `level level--${level(value)[0]}`, decimal(value, 2));
-
-// where that complexity stands, said in words - the note under the figure it belongs to
-function band(value) {
-    const [name, range] = level(value);
-
-    return element('span', `level level--${name}`, `${name} · ${range}`);
-}
-
-function row(label, value, hint) {
-    const node = element('div', 'analysis__row');
-    const definition = element('dd', 'analysis__value');
-
-    if (hint) {
-        definition.append(element('span', 'analysis__share', hint));
-    }
-
-    definition.append(value instanceof Node ? value : element('span', null, String(value)));
-    node.append(element('dt', 'analysis__label', label), definition);
-
-    return node;
-}
-
-function group(title, rows) {
-    const node = element('div');
-    const list = element('dl', 'analysis__list');
-
-    rows.filter(Boolean).forEach((entry) => list.append(entry));
-    node.append(element('div', 'analysis__title', title), list);
-
-    return node;
-}
 
 /*
  * One of the four figures a release comes down to, above the panel spelling it out. The note under a
  * value is what makes it a reading rather than a number: where a complexity stands on the scale, which
  * direction is the good one, what a size grew by, when the measuring started.
  */
-function headline(label, value, note, tone) {
+function headline(label, measured, note, tone) {
     const node = element('div', 'headline-figures__cell');
     const figure = element('div', `headline-figures__value${tone ? ` headline-figures__value--${tone}` : ''}`);
 
-    figure.append(value instanceof Node ? value : element('span', null, String(value)));
+    figure.append(measured instanceof Node ? measured : element('span', null, String(measured)));
     node.append(element('div', 'headline-figures__label', label), figure);
 
     if (note) {
@@ -144,7 +62,9 @@ export default class extends Controller {
         'count',
         'resetZoom',
         'select',
-        'metric',
+        'metrics',
+        'metricTabs',
+        'metricAbout',
         'release',
         'releaseTabs',
         'releasePanel',
@@ -152,6 +72,8 @@ export default class extends Controller {
         'releaseSelect',
         'headlineFigures',
         'analysis',
+        'measurement',
+        'measurementToggle',
         'raw',
         'rawTitle',
         'rawOutput',
@@ -164,10 +86,19 @@ export default class extends Controller {
             return;
         }
 
+        // what every number of the report is called, formatted and worth - rendered into the page by
+        // `MetricCatalog`, so nothing about a metric is written down twice
+        this.catalog = catalogFrom(this.element.dataset.catalog);
+        this.defaultMetric = [...this.catalog.values()].find((metric) => metric.default).slug;
+        // what the chart can be read in, in the order it tabs them, and which of those tabs is open
+        this.metrics = this.picked();
+        this.active = this.metricsTarget.dataset.active;
         // what the page was rendered with; everything picked later is fetched from the JSON route once
         this.graphs = new Map();
-        // and the raw phploc output of every release that was opened, which never changes once measured
+        // the raw phploc output of every release that was opened, which never changes once measured
         this.raws = new Map();
+        // and the same for the measurement behind it, read out through the catalog
+        this.measurements = new Map();
         // Turbo keeps the page as it looks when it is left, and an open dialog would come back open -
         // and then not modal, since only showModal() puts one in the top layer
         this.closeRawBeforeCache = () => this.closeRaw();
@@ -179,15 +110,23 @@ export default class extends Controller {
         // `<site> - <headline>`, so what is in front of the last dash is the part that stays
         this.site = document.title.split(' - ').slice(0, -1).join(' - ');
         this.renders = 0;
-        // a link says what it draws as well as what it draws it from, so the switch reads the address
-        // bar the way the repositories were read from it
-        this.metric = this.metricFrom(new URLSearchParams(window.location.search).get('metric'));
-        this.reflectMetric();
         // the lines that can be read release by release, and which one of them is being read
         this.series = [];
         this.repository = null;
+        this.releaseIndex = null;
+        this.measurementOpen = false;
+        // the lines the chart was last drawn from, so switching a tab is a redraw of what is already here
+        this.drawn = [];
         this.initChart();
         this.render();
+
+        /*
+         * A chart measures its own axis out of the width of its widest tick, and it draws before the
+         * webfont it will be set in has arrived - so a scale of hundreds of thousands is laid out in the
+         * fallback and comes back too narrow for its own numbers. Redrawing once the font is there is the
+         * whole fix; it costs one update and only ever happens once.
+         */
+        document.fonts?.ready.then(() => this.chart?.update('none'));
     }
 
     disconnect() {
@@ -207,6 +146,14 @@ export default class extends Controller {
             data: { datasets: [] },
             options: {
                 maintainAspectRatio: false,
+                /*
+                 * No animation. A line rising out of the floor is a thing the chart does, not a thing the
+                 * data does - fifteen years of releases were not on their way up, they were there when
+                 * the page was. It is the same statement the tabs above it make: switching one is a
+                 * redraw of numbers the page already has, and a chart catching up with itself reads as
+                 * if it were fetching something.
+                 */
+                animation: false,
                 interaction: { mode: 'nearest', intersect: false },
                 // whatever the tooltip is pointing at is what a click reads below the chart, so the
                 // point that answers the click is the one the pointer already named
@@ -231,8 +178,9 @@ export default class extends Controller {
                         bodyFont: { family: MONO, size: 12 },
                         callbacks: {
                             title: (items) => `${items[0].dataset.label} ${items[0].raw.name}`,
-                            // whichever number the lines are drawn as, named the way the switch names it
-                            label: (item) => `${this.metric.label}: ${item.formattedValue}`,
+                            // whichever number the lines are drawn as, named the way its tab names it
+                            label: (item) =>
+                                `${this.primary().label}: ${format(this.primary(), item.raw.values[this.active])}`,
                         },
                     },
                     zoom: {
@@ -257,7 +205,14 @@ export default class extends Controller {
                         beginAtZero: true,
                         border: { display: false },
                         grid: { color: GRID },
-                        ticks: { color: TICK, font: { family: MONO, size: 11 }, padding: 8 },
+                        ticks: {
+                            color: TICK,
+                            font: { family: MONO, size: 11 },
+                            padding: 8,
+                            // the axis is written the way its metric is written - three decimals for a
+                            // complexity per line, none for a count of half a million
+                            callback: (tick) => format(this.primary(), tick),
+                        },
                     },
                 },
             },
@@ -306,45 +261,119 @@ export default class extends Controller {
     }
 
     /**
-     * The picker above the chart is a box of its own and says what it holds by changing the select it
-     * is a widget for - which is also what the chart was rendered with, so adding a line and opening
-     * the page on it are the same thing to everything below.
+     * The picker on the top edge of the panel is a box of its own and says what it holds by changing the
+     * select it is a widget for - which is also what the chart was rendered with, so adding a line and
+     * opening the page on it are the same thing to everything below.
      */
     repick() {
         this.render(true);
     }
 
     /**
-     * The other number every release was measured in. Both are in the graphs the page already has, so
-     * this redraws rather than fetches - and it resets the zoom, because a window onto a complexity of
-     * four says nothing about a codebase of half a million lines.
+     * The same for the row under it: however a metric got into the chart or out of it - typed into the
+     * box, dropped from its tab, picked out of the measurement table under the chart - it is one event.
      */
-    selectMetric(event) {
-        const metric = this.metricFrom(event.currentTarget.dataset.metric);
-
-        if (metric === this.metric) {
-            return;
-        }
-
-        this.metric = metric;
-        this.reflectMetric();
-        this.chart?.resetZoom();
+    remetric() {
         this.render(true);
     }
 
-    metricFrom(name) {
-        return METRICS.find((metric) => metric.name === name) ?? METRICS[0];
+    /**
+     * What the select behind the tab row says the chart can be read in, in the order it tabs them.
+     */
+    picked() {
+        return this.hasMetricsTarget
+            ? [...this.metricsTarget.selectedOptions]
+                  .map((option) => option.value)
+                  .filter((slug) => this.catalog.has(slug))
+            : [];
     }
 
-    reflectMetric() {
-        this.metricTargets.forEach((button) => {
-            button.setAttribute('aria-selected', button.dataset.metric === this.metric.name ? 'true' : 'false');
-        });
+    metricOf(slug) {
+        return this.catalog.get(slug);
+    }
+
+    /**
+     * The metric the chart is open on: what its lines are drawn as, what a release is listed under in
+     * the select below it, and what the figures over the release analysis are read in.
+     */
+    primary() {
+        return this.metricOf(this.active);
+    }
+
+    /**
+     * Drawing a metric that is not drawn yet, from somewhere other than the box - the measurement table
+     * under the chart. It writes to the same select, so the box and the chart both hear about it.
+     */
+    drawMetric(slug) {
+        const option = [...this.metricsTarget.options].find((entry) => entry.value === slug);
+
+        if (!option || option.selected) {
+            return;
+        }
+
+        option.selected = true;
+        option.setAttribute('selected', 'selected');
+        // a pick goes to the end, which is where its tab goes - and the tab that was just added is the
+        // one the chart opens on, see render()
+        this.metricsTarget.append(option);
+        this.metricsTarget.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    /**
+     * Switching a tab. The years stay where the reader left them - that is the whole reason every metric
+     * is drawn in the same frame - while a zoom on the other axis goes, because it belonged to the number
+     * that was being read and says nothing about the next one.
+     */
+    selectMetric(slug) {
+        if (slug === this.active || !this.metrics.includes(slug)) {
+            return;
+        }
+
+        this.active = slug;
+        this.years = this.chart.isZoomedOrPanned()
+            ? { min: this.chart.scales.x.min, max: this.chart.scales.x.max }
+            : null;
+        this.chart.resetZoom('none');
+        this.syncUrl(this.drawn.map((graph) => graph.name));
+        this.draw();
+        this.renderMetricTabs();
+        // the release analysis is read in what the chart shows, so it follows the tab
+        this.showRepository(this.repository, this.releaseIndex);
+    }
+
+    /**
+     * Taking a metric out of the chart - from its tab, which is where it is switched to as well. A chart
+     * is always drawn as something, so the last tab carries no button at all.
+     */
+    dropMetric(slug) {
+        const option = [...this.metricsTarget.options].find((entry) => entry.value === slug);
+
+        if (!option || this.metrics.length < 2) {
+            return;
+        }
+
+        option.selected = false;
+        option.removeAttribute('selected');
+        this.metricsTarget.dispatchEvent(new Event('change', { bubbles: true }));
     }
 
     async render(picked = false) {
         const run = ++this.renders;
         const slugs = this.hasSelectTarget ? [...this.selectTarget.selectedOptions].map((option) => option.value) : [];
+        const before = this.metrics;
+
+        this.metrics = this.picked();
+
+        /*
+         * Adding a metric is asking to see it - whether it was typed into the box or clicked in the
+         * measurement table, what was just added is what the chart opens on. It is the same rule as
+         * further down for a metric that was taken out: a tab row answers for the tab that is open.
+         */
+        const added = this.metrics.filter((slug) => !before.includes(slug));
+
+        if (added.length > 0) {
+            this.active = added[added.length - 1];
+        }
 
         if (picked) {
             this.syncUrl(slugs);
@@ -357,12 +386,32 @@ export default class extends Controller {
             return;
         }
 
-        this.chart.data.datasets = graphs.map((graph, index) => ({
+        // a metric can be taken out of the chart while its tab is the one open
+        if (!this.metrics.includes(this.active)) {
+            this.active = this.metrics[0];
+        }
+
+        this.drawn = graphs;
+        this.draw();
+        this.renderMetricTabs();
+        this.renderHeadline(slugs);
+        this.renderCount(graphs);
+        this.renderTabs(graphs);
+    }
+
+    /**
+     * The lines, drawn as whatever the open tab reads them in. Every metric of the chart travels with
+     * every release, so this is the whole of switching one: no request, and the same points.
+     */
+    draw() {
+        this.metricAboutTarget.textContent = this.primary().about;
+
+        this.chart.data.datasets = this.drawn.map((graph, index) => ({
             label: graph.name,
             // the releases themselves, whichever of their numbers is being drawn - so a point stays the
             // release it is, and clicking one still opens it in the analysis below
             data: graph.tags,
-            parsing: { xAxisKey: 'x', yAxisKey: this.metric.key },
+            parsing: { xAxisKey: 'x', yAxisKey: `values.${this.active}` },
             fill: false,
             borderWidth: 1.75,
             pointRadius: 2.5,
@@ -372,11 +421,60 @@ export default class extends Controller {
         }));
 
         this.chart.update();
-        this.reflectZoom();
 
-        this.renderHeadline(slugs);
-        this.renderCount(graphs);
-        this.renderTabs(graphs);
+        // a tab switch keeps the years it was left on - see selectMetric()
+        if (this.years) {
+            this.chart.zoomScale('x', this.years, 'none');
+            this.years = null;
+        }
+
+        this.reflectZoom();
+    }
+
+    /**
+     * The metrics of this chart, as the tabs they are read through - the same underline tabs the release
+     * analysis picks a repository with, since it is the same act: one thing at a time, in one place. They
+     * stand on the hairline the chart hangs under, so the tab that is open underlines the frame it draws
+     * in.
+     *
+     * Unlike the repositories below, a single one of them is still a tab: with nothing to switch to it
+     * is not a choice but a label, and it is the only place the chart says which number it is drawing.
+     */
+    renderMetricTabs() {
+        if (!this.hasMetricTabsTarget) {
+            return;
+        }
+
+        this.metricTabsTarget.replaceChildren(
+            ...this.metrics.map((slug) => {
+                const metric = this.metricOf(slug);
+                const tab = element('button', 'tab');
+
+                tab.type = 'button';
+                tab.title = metric.about;
+                tab.setAttribute('role', 'tab');
+                tab.setAttribute('aria-controls', 'chart-canvas');
+                tab.setAttribute('aria-selected', slug === this.active ? 'true' : 'false');
+                tab.append(element('span', null, metric.label));
+                tab.addEventListener('click', () => this.selectMetric(slug));
+
+                // a chart is always drawn as something, so the last tab is not one that can be closed
+                if (this.metrics.length > 1) {
+                    const drop = element('button', 'tab__drop', '×');
+
+                    drop.type = 'button';
+                    drop.setAttribute('aria-label', `Take ${metric.label} out of this chart`);
+                    drop.addEventListener('mousedown', (event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        this.dropMetric(slug);
+                    });
+                    tab.append(drop);
+                }
+
+                return tab;
+            }),
+        );
     }
 
     /**
@@ -419,7 +517,8 @@ export default class extends Controller {
 
     /**
      * A chart is worth sharing, so what is in it belongs in the address bar - the same query string the
-     * page reads on load. Only after a pick: opening the default chart leaves its url alone.
+     * page reads on load, repositories and metrics alike. Only after a pick: opening the default chart
+     * leaves its url alone.
      */
     syncUrl(slugs) {
         const params = new URLSearchParams(window.location.search);
@@ -430,11 +529,18 @@ export default class extends Controller {
             params.delete('repositories');
         }
 
-        // the metric the chart opens on is the one the report is about, so it is the absence of one
-        if (this.metric === METRICS[0]) {
+        // the chart the report is about carries no metric at all
+        if (1 === this.metrics.length && this.defaultMetric === this.metrics[0]) {
+            params.delete('metrics');
+        } else {
+            params.set('metrics', this.metrics.join(','));
+        }
+
+        // and which tab is open is only worth writing down when it is not the one a link opens on
+        if (this.active === this.metrics[0]) {
             params.delete('metric');
         } else {
-            params.set('metric', this.metric.name);
+            params.set('metric', this.active);
         }
 
         // `symfony/console,laravel/framework` is what this was typed as, and what it should stay
@@ -443,22 +549,46 @@ export default class extends Controller {
         window.history.replaceState({}, '', query ? `?${query}` : window.location.pathname);
     }
 
+    /**
+     * A line of the chart, in the numbers the chart is currently drawn as. A repository that was never
+     * picked before is fetched whole; one that is already drawn is asked only for the metric that was
+     * just added, and what it already carries is kept.
+     */
     async load(slug) {
-        if (!this.graphs.has(slug)) {
-            // the slug is the whole route, so a relative request keeps working under a deployed sub path
-            const response = await fetch(slug, { headers: { Accept: 'application/json' } });
+        const known = this.graphs.get(slug);
+        const missing = this.metrics.filter((metric) => !known || !known.metrics.includes(metric));
 
-            // the route answers with the line itself, the same shape the page was rendered with
-            this.graphs.set(slug, await response.json());
+        if (known && 0 === missing.length) {
+            return known;
         }
 
-        return this.graphs.get(slug);
+        // the slug is the whole route, so a relative request keeps working under a deployed sub path
+        const response = await fetch(`${slug}?metrics=${(known ? missing : this.metrics).join(',')}`, {
+            headers: { Accept: 'application/json' },
+        });
+        // the route answers with the line itself, the same shape the page was rendered with
+        const graph = await response.json();
+
+        if (known) {
+            const carried = new Map(known.tags.map((tag) => [tag.name, tag.values]));
+
+            // the answer is the newest release list, so it leads and what was already read joins it
+            graph.tags.forEach((tag) => Object.assign(tag.values, carried.get(tag.name)));
+            graph.metrics = [...new Set([...known.metrics, ...graph.metrics])];
+        }
+
+        this.graphs.set(slug, graph);
+
+        return graph;
     }
 
     /**
      * The measurement below the chart is one tab per line: every repository in the chart can be read
      * release by release, not only the one the page was opened with. The tab carries the colour its
      * series is drawn in, so a line and its numbers are found by the same swatch.
+     *
+     * A single line is still a tab, the way a single metric is: with nothing to switch to it is not a
+     * choice but a label, and the rail would otherwise say nothing about whose release is being read.
      */
     renderTabs(graphs) {
         if (!this.hasReleaseTarget) {
@@ -488,15 +618,12 @@ export default class extends Controller {
             }),
         );
 
-        // one line is not a choice
-        this.releaseTabsTarget.hidden = this.series.length < 2;
-
         // whoever was being read stays it, as long as its line is still in the chart
         const read = this.series.some((graph) => graph.name === this.repository)
             ? this.repository
             : this.series[0].name;
 
-        this.showRepository(read);
+        this.showRepository(read, this.releaseIndex);
     }
 
     selectRepository(event) {
@@ -505,7 +632,7 @@ export default class extends Controller {
 
     /**
      * Reading a repository starts at its newest release, unless the reader said which one - clicking a
-     * point in the chart does.
+     * point in the chart does, and so does a redraw of the release that was already open.
      */
     showRepository(name, index = null) {
         const graph = this.series.find((entry) => entry.name === name);
@@ -513,6 +640,8 @@ export default class extends Controller {
         if (!graph) {
             return;
         }
+
+        const metric = this.primary();
 
         this.repository = name;
 
@@ -538,16 +667,16 @@ export default class extends Controller {
 
         this.releaseSelectTarget.replaceChildren();
 
-        graph.tags.forEach((tag, index) => {
-            // the release, and what it stands at in whatever the chart is drawing
-            const option = element('option', null, `${tag.name}  ·  ${this.metric.short(tag[this.metric.key])}`);
+        graph.tags.forEach((tag, position) => {
+            // the release, and what it stands at in whatever the chart is open on
+            const option = element('option', null, `${tag.name}  ·  ${format(metric, tag.values[metric.slug])}`);
 
-            option.value = String(index);
+            option.value = String(position);
             // newest first, the way the report is read
             this.releaseSelectTarget.prepend(option);
         });
 
-        this.showRelease(null === index ? graph.tags.length - 1 : index);
+        this.showRelease(null === index || index >= graph.tags.length ? graph.tags.length - 1 : index);
     }
 
     selectRelease(event) {
@@ -559,57 +688,288 @@ export default class extends Controller {
         const tag = tags[index];
         const previous = index > 0 ? tags[index - 1] : undefined;
         const first = tags[0];
+        const metric = this.primary();
 
+        // what a redraw comes back to, so switching a tab does not jump the reader to the newest release
+        this.releaseIndex = index;
         this.releaseSelectTarget.value = String(index);
 
-        const lowest = tags.reduce((left, right) => (right.y < left.y ? right : left));
-        const highest = tags.reduce((left, right) => (right.y > left.y ? right : left));
-        const step = previous ? Math.round((tag.y - previous.y) * 100) / 100 : 0;
-        const grew = previous ? tag.loc - previous.loc : 0;
+        this.renderFigures(tag, previous, first, tags);
 
-        /*
-         * What the release comes down to, before the panel below spells it out. The date it carries is
-         * the day it was tagged, not the day the report measured it - the measurement happened whenever
-         * the repository was submitted or a nightly scan picked the release up, which is not what anyone
-         * reading a release is after.
-         */
-        this.headlineFiguresTarget.replaceChildren(
-            headline('Ø complexity', decimal(tag.y, 2), band(tag.y)),
-            previous
-                ? headline(`vs ${previous.name}`, signed(step, 2), 'down is an improvement', tone(step))
-                : headline('vs the release before', '–', 'nothing was measured before it'),
-            headline(
-                'Lines of code',
-                count(tag.loc),
-                previous ? `${signed(grew)} · ${share(grew, previous.loc) ?? '–'}` : 'as phploc counts them',
-            ),
-            headline('Analysed releases', count(tags.length), `first one ${day(first.date)}`),
+        this.analysisTarget.replaceChildren(
+            ...[
+                group('This release', [
+                    row('Released', day(tag.date)),
+                    ...this.metrics.map((slug) => {
+                        const drawn = this.metricOf(slug);
+
+                        return row(drawn.label, value(drawn, tag.values[slug]));
+                    }),
+                ]),
+                tag !== first ? this.comparison(`Since ${first.name}`, tag, first) : null,
+                // where this release stands among the others, and what the repository behind them is
+                group(`All ${tags.length} releases`, [
+                    ...this.extremes(metric, tags),
+                    row('Stars on GitHub', stars(this.release.stars)),
+                ]),
+            ].filter(Boolean),
         );
 
-        const groups = [
-            group('This release', [
-                row('Released', day(tag.date)),
-                row('Lines of code', count(tag.loc)),
-                row('Ø complexity', complexity(tag.y)),
-            ]),
-            tag !== first
-                ? group(`Since ${first.name}`, [
-                      row('Lines of code', signed(tag.loc - first.loc), share(tag.loc - first.loc, first.loc)),
-                      row('Ø complexity', trend(Math.round((tag.y - first.y) * 100) / 100, 2)),
-                  ])
-                : null,
-            // where this release stands among the others, and what the repository behind them is
-            group(`All ${tags.length} releases`, [
-                row('Lowest Ø complexity', complexity(lowest.y), lowest.name),
-                row('Highest Ø complexity', complexity(highest.y), highest.name),
-                row('Stars on GitHub', stars(this.release.stars)),
-            ]),
-        ];
-
-        this.analysisTarget.replaceChildren(...groups.filter(Boolean));
-
-        // the release the modal would show
+        // the release the measurement and the raw output are read for
         this.tag = tag;
+        this.reflectMeasurement();
+    }
+
+    /**
+     * What the release comes down to, before the panel below spells it out - the first three of them read
+     * in whichever metric the chart is open on, since that is the one being looked at. The other tabs
+     * answer the same three questions by being switched to.
+     *
+     * The date a release carries is the day it was tagged, not the day the report measured it - that
+     * happened whenever the repository was submitted or a nightly scan picked the release up, which is
+     * not what anyone reading a release is after.
+     */
+    renderFigures(tag, previous, first, tags) {
+        const metric = this.primary();
+        const measured = tag.values[metric.slug];
+        const step = previous ? this.delta(metric, tag, previous) : null;
+        const since = tag === first ? null : this.delta(metric, tag, first);
+
+        this.headlineFiguresTarget.replaceChildren(
+            headline(
+                metric.label,
+                value(metric, measured),
+                // the dot in front of a complexity carries its band as a colour, so the note names it;
+                // every other number is a count, and what it is read against is when it was counted
+                metric.level && null !== measured && undefined !== measured ? band(measured) : day(tag.date),
+            ),
+            null === step
+                ? headline('vs the release before', '–', 'nothing was measured before it')
+                : headline(
+                      `vs ${previous.name}`,
+                      this.movement(metric, step),
+                      // only where the report has an opinion about a direction is a colour worth
+                      // explaining; everywhere else the reading is how much of the number moved
+                      'lower' === metric.direction
+                          ? 'down is an improvement'
+                          : (this.portion(step, previous.values[metric.slug]) ?? 'as phploc counts it'),
+                      direction(metric, step),
+                  ),
+            null === since
+                ? headline('Since the first release', '–', 'this is the first one')
+                : headline(
+                      `Since ${first.name}`,
+                      this.movement(metric, since),
+                      this.portion(since, first.values[metric.slug]) ?? day(first.date),
+                      direction(metric, since),
+                  ),
+            headline('Analysed releases', count(tags.length), `first one ${day(first.date)}`),
+        );
+    }
+
+    /**
+     * A change as a plain figure. The arrow and the chip belong to a row of the panel below, where a
+     * number is one line of a list; up here the figure is the whole cell and its colour says as much.
+     */
+    movement(metric, delta) {
+        return `${delta > 0 ? '+' : delta < 0 ? '−' : '±'}${format(metric, Math.abs(delta))}`;
+    }
+
+    /**
+     * How much of the number that change was. A share is written as a magnitude wherever it stands next
+     * to what it is a share of - here it stands under a figure that is itself a change, so it carries
+     * the same sign, or it would read as a rise under a fall.
+     */
+    portion(delta, whole) {
+        const measured = share(delta, whole);
+
+        return undefined === measured ? undefined : `${delta < 0 ? '−' : '+'}${measured}`;
+    }
+
+    /**
+     * Where this release stands among the others, in the metric the chart is open on - with the release
+     * that holds the record next to it, since that is what makes it a place rather than a number.
+     */
+    extremes(metric, tags) {
+        const measured = tags
+            .map((tag) => tag.values[metric.slug])
+            .filter((entry) => null !== entry && undefined !== entry);
+
+        if (0 === measured.length) {
+            return [];
+        }
+
+        const lowest = Math.min(...measured);
+        const highest = Math.max(...measured);
+        // only the first letter, so `Lines of code (LOC)` keeps the acronym it carries
+        const named = metric.label.charAt(0).toLowerCase() + metric.label.slice(1);
+        const held = (by) => tags.find((tag) => tag.values[metric.slug] === by)?.name;
+
+        return [
+            row(`Lowest ${named}`, value(metric, lowest), held(lowest)),
+            row(`Highest ${named}`, value(metric, highest), held(highest)),
+        ];
+    }
+
+    /**
+     * The release against another one, in every number the chart is drawn as - a percentage next to it
+     * wherever there is something to be a percentage of.
+     */
+    comparison(title, tag, other) {
+        return group(
+            title,
+            this.metrics.map((slug) => {
+                const metric = this.metricOf(slug);
+                const delta = this.delta(metric, tag, other);
+
+                return null === delta
+                    ? row(metric.label, '—')
+                    : row(metric.label, change(metric, delta), share(delta, other.values[slug]));
+            }),
+        );
+    }
+
+    delta(metric, tag, other) {
+        const measured = tag.values[metric.slug];
+        const before = other.values[metric.slug];
+
+        if (null === measured || undefined === measured || null === before || undefined === before) {
+            return null;
+        }
+
+        return Number((measured - before).toFixed(metric.decimals));
+    }
+
+    /**
+     * Everything phploc counted for this release, which is sixty-two numbers of which the chart draws a
+     * handful. It is fetched for the release that is open rather than carried by the page, and kept
+     * afterwards - a measurement does not change once it was taken.
+     */
+    toggleMeasurement() {
+        this.measurementOpen = !this.measurementOpen;
+        this.reflectMeasurement();
+    }
+
+    reflectMeasurement() {
+        if (!this.hasMeasurementTarget) {
+            return;
+        }
+
+        this.measurementToggleTarget.setAttribute('aria-expanded', this.measurementOpen ? 'true' : 'false');
+        this.measurementTarget.hidden = !this.measurementOpen;
+
+        if (this.measurementOpen) {
+            this.renderMeasurement();
+        }
+    }
+
+    async renderMeasurement() {
+        const release = this.release;
+        const tag = this.tag;
+        // the metrics are part of it: what the chart already draws is marked in the table, so picking
+        // one out of the table is a row of it changing
+        const key = `${release.name}@${tag.name}|${this.metrics.join(',')}`;
+
+        if (this.measurementKey === key) {
+            return;
+        }
+
+        this.measurementKey = key;
+        this.measurementTarget.replaceChildren(element('p', 'measurement__note', 'Reading the measurement…'));
+
+        const measurement = await this.loadMeasurement(release.name, tag.name);
+
+        // reading is not instant, and another release can be opened meanwhile
+        if (this.tag !== tag || !this.measurementOpen) {
+            return;
+        }
+
+        if (!measurement) {
+            this.measurementKey = null;
+            this.measurementTarget.replaceChildren(
+                element('p', 'measurement__note', 'The measurement of this release could not be read.'),
+            );
+
+            return;
+        }
+
+        this.measurementTarget.replaceChildren(...this.measurementGroups(measurement));
+    }
+
+    /**
+     * The measurement in the sections phploc prints it in, every number under the one it is a part of,
+     * and against the release before it - which is the whole difference between this and the raw
+     * output next to it: the same numbers, read rather than reprinted.
+     */
+    measurementGroups(measurement) {
+        const sections = new Map();
+
+        this.catalog.forEach((metric) => {
+            if (!sections.has(metric.group)) {
+                sections.set(metric.group, { label: metric.groupLabel, about: metric.groupAbout, rows: [] });
+            }
+
+            sections.get(metric.group).rows.push(this.measurementRow(metric, measurement));
+        });
+
+        return [...sections.values()].map((section) => {
+            const node = element('div', 'measurement__group');
+
+            node.append(
+                element('div', 'analysis__title', section.label),
+                element('p', 'measurement__about', section.about),
+                list(section.rows),
+            );
+
+            return node;
+        });
+    }
+
+    measurementRow(metric, measurement) {
+        const measured = measurement.values[metric.slug] ?? null;
+        const before = measurement.previous?.values[metric.slug] ?? null;
+        const label = element('dt', 'analysis__label');
+        const pick = element('button', 'measurement__pick', metric.label);
+        const definition = element('span', 'measurement__numbers');
+
+        pick.type = 'button';
+        pick.title = `${metric.about} - click to draw it`;
+        pick.disabled = this.metrics.includes(metric.slug);
+        pick.addEventListener('click', () => this.drawMetric(metric.slug));
+        label.style.paddingLeft = `calc(var(--space-4) * ${metric.depth})`;
+        label.append(pick);
+
+        if (null !== measured && null !== before) {
+            definition.append(change(metric, Number((measured - before).toFixed(metric.decimals))));
+        }
+
+        definition.prepend(value(metric, measured));
+
+        return row(label, definition, percent(measurement.shares[metric.slug]));
+    }
+
+    async loadMeasurement(name, tag) {
+        const key = `${name}@${tag}`;
+
+        if (!this.measurements.has(key)) {
+            // relative, like the routes above, so it keeps working under a deployed sub path
+            const path = `${name}/${encodeURIComponent(tag)}/metrics`;
+
+            try {
+                const response = await fetch(path, { headers: { Accept: 'application/json' } });
+
+                if (!response.ok) {
+                    throw new Error(String(response.status));
+                }
+
+                this.measurements.set(key, await response.json());
+            } catch {
+                // not cached: a failure is worth trying again, unlike a measurement
+                return null;
+            }
+        }
+
+        return this.measurements.get(key);
     }
 
     /**

--- a/assets/controllers/metric_picker_controller.js
+++ b/assets/controllers/metric_picker_controller.js
@@ -1,0 +1,111 @@
+import { Controller } from '@hotwired/stimulus';
+import { Combobox } from '../combobox.js';
+import { element } from '../dom.js';
+
+/*
+ * The box above the chart that says what it is drawn as. It is the repository box next to it, over a
+ * list that is already in the page: a release was measured in fifty-four numbers, and nothing has to be
+ * asked of the server to know their names - so this box searches what it was rendered with.
+ *
+ * That is also why a row says more than a name here. Nobody knows what `Logical lines outside classes
+ * and functions` is before reading what it counts, so the menu carries the sentence the catalog holds
+ * for every metric, under the section phploc prints it in.
+ *
+ * The select behind it is the state, not the widget - see repository_picker_controller.js. What is
+ * picked shows up as a tab above the chart rather than as a chip in here: the metrics of a chart are
+ * what it can be read in, and that list is the tab row, not a second copy of it next to the field.
+ * So this box only ever adds - a tab is where a metric is switched to and taken out again.
+ */
+export default class extends Controller {
+    static targets = ['select', 'input', 'menu'];
+
+    connect() {
+        this.combobox = new Combobox(this.inputTarget, this.menuTarget, (index) => this.pick(index));
+        // turbo caches the page as it was left, so a box left open would come back open
+        this.combobox.close();
+        this.inputTarget.value = '';
+    }
+
+    disconnect() {
+        this.combobox.close();
+    }
+
+    /** The whole box is one field, so clicking it aims for the only thing in it. */
+    focus() {
+        this.inputTarget.focus();
+    }
+
+    /**
+     * Everything that was measured and is not drawn yet. What is typed is matched against the name, the
+     * section and the sentence explaining the metric - `static` finds the static methods and the calls
+     * on them, `branch` finds the complexities, which are the words their explanations are written in.
+     */
+    query() {
+        const search = this.inputTarget.value.trim().toLowerCase();
+
+        this.options = [...this.selectTarget.options].filter(
+            (option) => !option.selected && this.haystack(option).includes(search),
+        );
+
+        this.combobox.show(
+            this.options.map((option) => {
+                const row = element('li', 'combobox__option');
+
+                row.append(
+                    element('span', 'combobox__name', option.text),
+                    element('span', 'combobox__meta', option.dataset.group),
+                    element('span', 'combobox__description', option.dataset.about),
+                );
+
+                return row;
+            }),
+            this.nothing('' !== search),
+        );
+    }
+
+    haystack(option) {
+        return `${option.text} ${option.dataset.group} ${option.dataset.about} ${option.value}`.toLowerCase();
+    }
+
+    nothing(searching) {
+        return searching
+            ? 'Nothing that was measured goes by that name.'
+            : 'Every number of the measurement is already in this chart.';
+    }
+
+    navigate(event) {
+        this.combobox.navigate(event);
+    }
+
+    close() {
+        this.combobox.close();
+    }
+
+    pick(index) {
+        const option = this.options[index];
+
+        if (!option) {
+            return;
+        }
+
+        option.selected = true;
+        option.setAttribute('selected', 'selected');
+        // the position of an option is the position of its tab, so a pick goes to the end of both
+        this.selectTarget.append(option);
+        // one pick is rarely the only one, so the box stays open on what is left of the measurement
+        this.inputTarget.value = '';
+        this.commit();
+    }
+
+    commit() {
+        this.selectTarget.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    /** What the select says, whoever wrote to it - the box only ever shows what is not in the chart. */
+    refresh() {
+        // the menu is what is not in the chart, so taking a metric out puts it back on
+        if (!this.menuTarget.hidden) {
+            this.query();
+        }
+    }
+}

--- a/assets/controllers/repository_picker_controller.js
+++ b/assets/controllers/repository_picker_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
-import { Combobox, element } from '../combobox.js';
+import { Combobox } from '../combobox.js';
+import { element } from '../dom.js';
 
 /*
  * The box above the chart: which repositories it draws. It is the start page's combobox with more than

--- a/assets/controllers/search_controller.js
+++ b/assets/controllers/search_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
-import { Combobox, element } from '../combobox.js';
+import { Combobox } from '../combobox.js';
+import { element } from '../dom.js';
 
 /*
  * The search box on the start page. It asks the server what an input means - a repository the report

--- a/assets/dom.js
+++ b/assets/dom.js
@@ -1,0 +1,18 @@
+/*
+ * One element, built. Everything the report renders in the browser - the rows of a combobox, the tabs
+ * of the release analysis, sixty-two numbers of a measurement - is built rather than written into a
+ * string, so this is the one line that would otherwise be written a hundred times.
+ */
+export function element(tag, className, text) {
+    const node = document.createElement(tag);
+
+    if (className) {
+        node.className = className;
+    }
+
+    if (undefined !== text) {
+        node.textContent = text;
+    }
+
+    return node;
+}

--- a/assets/metrics.js
+++ b/assets/metrics.js
@@ -1,0 +1,158 @@
+/*
+ * How the report writes a measured number down.
+ *
+ * The catalog itself - what a number is called, which section it is printed under, how far it is
+ * rounded, whether falling is an improvement - is rendered into the page by `MetricCatalog`, so none of
+ * it is repeated here. What is here is the other half: turning one of those numbers, or the difference
+ * between two of them, into the element it is read as.
+ */
+import { element } from './dom.js';
+
+const ARROWS = { good: '↓', bad: '↑', flat: '→' };
+
+/*
+ * The risk bands of `ComplexityLevel`, mirrored because the release analysis is built here in the
+ * browser rather than rendered. It is the one thing about a metric the catalog does not carry: four
+ * numbers, and the band above the last of them.
+ */
+const LEVELS = [
+    [10, 'simple', '1–10'],
+    [20, 'moderate', '11–20'],
+    [50, 'complex', '21–50'],
+];
+const UNTESTABLE = ['untestable', '> 50'];
+
+const bandOf = (value) => LEVELS.find(([limit]) => value <= limit)?.slice(1) ?? UNTESTABLE;
+
+export const level = (value) => bandOf(value)[0];
+
+/**
+ * Where a complexity stands, said in words - the note under the figure it belongs to, since the dot in
+ * front of the figure carries the band as a colour but not as a name.
+ */
+export function band(measured) {
+    const [name, range] = bandOf(measured);
+
+    return element('span', `level level--${name}`, `${name} · ${range}`);
+}
+
+/**
+ * Everything the page was told about the numbers it may draw, by the slug they are addressed under.
+ */
+export function catalogFrom(json) {
+    return new Map(JSON.parse(json).map((metric) => [metric.slug, metric]));
+}
+
+const digits = (value, decimals) =>
+    value.toLocaleString('en-US', { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+
+/**
+ * A measured number, written with the decimals its metric is read to - a count without any, an average
+ * with two. A release that does not carry the number at all is a dash rather than a zero, because
+ * those are different statements.
+ */
+export function format(metric, value) {
+    return null === value || undefined === value ? '—' : digits(value, metric.decimals);
+}
+
+const sign = (value) => (value > 0 ? '+' : value < 0 ? '−' : '±');
+
+export function signed(metric, delta) {
+    return sign(delta) + digits(Math.abs(delta), metric.decimals);
+}
+
+/**
+ * What a part is of its whole, which is the percentage phploc prints behind half of its numbers.
+ */
+export function share(part, total) {
+    return total ? `${digits((Math.abs(part) / total) * 100, 1)}%` : undefined;
+}
+
+export function percent(value) {
+    return undefined === value || null === value ? undefined : `${digits(value, 1)}%`;
+}
+
+/**
+ * A measured value, carrying the dot of its risk band where the metric is one that is read against
+ * them - the complexities, and nothing else.
+ */
+export function value(metric, measured) {
+    if (!metric.level || null === measured || undefined === measured) {
+        return element('span', null, format(metric, measured));
+    }
+
+    return element('span', `level level--${level(measured)}`, format(metric, measured));
+}
+
+/**
+ * Which way a change goes, where the report has an opinion about it: complexity falling is an
+ * improvement and complexity rising is a regression, while a library that grew by twenty thousand lines
+ * did not thereby get better or worse - so a neutral metric has no direction at all, not a flat one.
+ *
+ * What counts as no movement is what the metric is written to: half of its last decimal.
+ */
+export function direction(metric, delta) {
+    if ('lower' !== metric.direction) {
+        return undefined;
+    }
+
+    return Math.abs(delta) < Math.pow(10, -metric.decimals) / 2 ? 'flat' : delta < 0 ? 'good' : 'bad';
+}
+
+/**
+ * A change, coloured only where the report has an opinion about the direction.
+ */
+export function change(metric, delta, label) {
+    if ('lower' !== metric.direction) {
+        const node = element('span', 'trend trend--chip trend--flat');
+
+        node.append(element('span', null, signed(metric, delta)));
+
+        if (label) {
+            node.append(element('span', 'trend__label', label));
+        }
+
+        return node;
+    }
+
+    const tone = direction(metric, delta);
+    const node = element('span', `trend trend--chip trend--${tone}`);
+
+    node.append(element('span', null, ARROWS[tone]), element('span', null, signed(metric, delta)));
+
+    if (label) {
+        node.append(element('span', 'trend__label', label));
+    }
+
+    return node;
+}
+
+export function row(label, measured, hint) {
+    const node = element('div', 'analysis__row');
+    const definition = element('dd', 'analysis__value');
+
+    if (hint) {
+        definition.append(element('span', 'analysis__share', hint));
+    }
+
+    definition.append(measured instanceof Node ? measured : element('span', null, String(measured)));
+    node.append(label instanceof Node ? label : element('dt', 'analysis__label', label), definition);
+
+    return node;
+}
+
+export function list(rows) {
+    const node = element('dl', 'analysis__list');
+
+    rows.filter(Boolean).forEach((entry) => node.append(entry));
+
+    return node;
+}
+
+export function group(title, rows) {
+    const node = element('div');
+
+    node.append(element('div', 'analysis__title', title), list(rows));
+
+    return node;
+}

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -185,10 +185,6 @@
 // Tabs that stand for the lines of a chart: each one carries the colour of its series, by the same
 // rule the chips in the repository box follow - the position of a tab is the colour of its line.
 .tabs--series {
-    &[hidden] {
-        display: none;
-    }
-
     .tab {
         font-family: var(--font-mono);
     }
@@ -206,6 +202,38 @@
         .tab:nth-child(8n + #{$index}) .tab__swatch {
             background: var(--chart-#{$index});
         }
+    }
+}
+
+// Tabs that stand for what the chart is read as: a second metric is a tab and not a second axis, since
+// colour already says which repository a line belongs to and cannot also say which number it is. They
+// sit on the hairline closing the panel head, so the head carries the rail and this row does not.
+.tabs--metrics {
+    flex: 1 1 auto;
+    gap: var(--space-4);
+    border-bottom: 0;
+
+    .tab {
+        font-family: var(--font-mono);
+        gap: var(--space-2);
+    }
+}
+
+// Taking the metric out of the chart, on the tab that reads it - it is not on the last one, since a
+// chart is always drawn as something, and it is a hair quieter than the name it stands behind.
+.tab__drop {
+    padding: 0 0 0 2px;
+    font-size: 13px;
+    line-height: 1;
+    color: var(--text-faint);
+    background: none;
+    border: 0;
+    cursor: pointer;
+    transition: color var(--transition);
+
+    &:hover,
+    &:focus-visible {
+        color: var(--trend-regressing);
     }
 }
 
@@ -415,6 +443,13 @@
         font-size: var(--text-xs);
         color: var(--text-faint);
     }
+}
+
+// The figures and the panel spelling them out are two readings of the same release, not one box - so
+// the panel follows them at the distance they follow the rail at, rather than sitting flush against
+// them and reading as the bottom half of the same grid.
+.headline-figures + .panel {
+    margin-top: var(--space-5);
 }
 
 @media (max-width: 900px) {
@@ -759,55 +794,6 @@ a.pill:hover .pill__value--state {
     height: 440px;
 }
 
-// What the chart draws, on the top edge of the panel it draws it in - the two numbers a release is
-// measured in, side by side rather than in a select, because there are two of them and both are worth
-// naming.
-//
-// It is a segmented control rather than two quiet words: the sunken track is what says that both of
-// them are options and one of them is taken, which a label on its own cannot say. So the track carries
-// the affordance and the raised half carries the state, the way a switch is read everywhere else.
-.chart-metrics {
-    display: flex;
-    flex: 0 0 auto;
-    gap: 2px;
-    width: fit-content;
-    padding: 2px;
-    background: var(--surface-muted);
-    border: var(--border-width) solid var(--line);
-    border-radius: var(--radius);
-}
-
-.metric-switch {
-    padding: 4px var(--space-3);
-    font-family: var(--font-mono);
-    font-size: var(--text-xs);
-    color: var(--text-muted);
-    background: transparent;
-    border: 0;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition:
-        color var(--transition),
-        background-color var(--transition);
-
-    &:hover {
-        color: var(--text-heading);
-        background: rgba(255, 255, 255, 0.6);
-    }
-
-    // the one that is taken is lifted out of the track, which is the whole statement of the control
-    &[aria-selected='true'] {
-        color: var(--text-heading);
-        background: var(--surface-card);
-        box-shadow: var(--shadow-xs);
-    }
-
-    &:focus-visible {
-        outline: none;
-        box-shadow: var(--focus-ring);
-    }
-}
-
 // The way out of a zoom, floating over the top right corner of the chart - only there while the chart
 // is zoomed or panned, so an untouched chart carries nothing.
 .chart-reset {
@@ -941,6 +927,115 @@ a.pill:hover .pill__value--state {
         font-family: var(--font-mono);
         font-size: var(--text-xs);
         color: var(--text-faint);
+    }
+}
+
+// --- Measurement ------------------------------------------------------------------------------
+// The rest of the release: every number phploc counted, under the heading it was printed under and
+// against the release before it. It stands folded under the panel above, because that panel is the
+// release read in what the chart draws and this is the answer to "and what else was measured".
+.measurement {
+    margin-top: var(--space-6);
+    padding-top: var(--space-4);
+    border-top: var(--border-width) solid var(--line);
+
+    &__toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 0;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        letter-spacing: var(--tracking-eyebrow);
+        text-transform: uppercase;
+        color: var(--text-muted);
+        background: none;
+        border: 0;
+        cursor: pointer;
+        transition: color var(--transition);
+
+        &:hover {
+            color: var(--text-heading);
+        }
+
+        &:focus-visible {
+            outline: none;
+            box-shadow: var(--focus-ring);
+        }
+
+        // the chevron turns down as the block opens, which is the whole animation of the control
+        .fas {
+            font-size: 10px;
+            color: var(--text-faint);
+            transition: transform var(--transition);
+        }
+
+        &[aria-expanded='true'] .fas {
+            transform: rotate(90deg);
+        }
+    }
+
+    // The four sections are of very different lengths - phploc counts six complexities and twenty-two
+    // structural numbers - so they are poured into columns rather than laid into a grid: a grid gives
+    // every section the height of the longest one standing next to it, which is half a screen of
+    // nothing under the short ones.
+    &__body {
+        columns: 320px 3;
+        column-gap: var(--space-7);
+        margin-top: var(--space-5);
+    }
+
+    &__group {
+        // a section is read as one thing, so it moves to the next column whole where it fits in one
+        break-inside: avoid-column;
+        margin-bottom: var(--space-6);
+    }
+
+    &__about {
+        margin: var(--space-2) 0 var(--space-3);
+        font-size: var(--text-xs);
+        color: var(--text-faint);
+    }
+
+    &__note {
+        margin: var(--space-4) 0 0;
+        font-size: var(--text-sm);
+        color: var(--text-muted);
+    }
+
+    // every number of the catalog can be drawn, so its name is the way into the chart
+    &__pick {
+        padding: 0;
+        font-family: inherit;
+        font-size: inherit;
+        text-align: left;
+        color: var(--text-body);
+        background: none;
+        border: 0;
+        cursor: pointer;
+
+        &:hover:not(:disabled) {
+            color: var(--text-heading);
+            text-decoration: underline;
+        }
+
+        // what the chart already draws is not something to add to it
+        &:disabled {
+            color: var(--text-heading);
+            font-weight: var(--weight-medium);
+            cursor: default;
+        }
+
+        &:focus-visible {
+            outline: none;
+            box-shadow: var(--focus-ring);
+        }
+    }
+
+    &__numbers {
+        display: inline-flex;
+        align-items: baseline;
+        gap: var(--space-3);
     }
 }
 

--- a/assets/styles/_screens.scss
+++ b/assets/styles/_screens.scss
@@ -106,41 +106,56 @@
     margin-top: var(--space-6);
 }
 
-// The chart and everything about it in one panel: what it is drawn from on the top edge, what it is
-// drawn as next to that, the chart itself, and what it is made of on the bottom edge. The panel pads
-// the chart and nothing else, so the two edges run to its full width.
+// The chart and everything about it in one panel: what it is drawn from on the top edge, what those
+// same lines are read as under it, the chart itself, and what it is made of on the bottom edge. The
+// panel pads the chart and nothing else, so the two edges run to its full width.
 .chart-panel {
     padding: 0;
 
-    &__head,
+    // Two rows, because they are two questions: which repositories, and in which number. The second one
+    // has no padding under it - the tabs end on the hairline closing the head, so whichever one is open
+    // underlines the frame it draws in rather than carrying a rail of its own.
+    &__head {
+        padding: var(--space-4) var(--space-5) 0;
+        border-bottom: var(--border-width) solid var(--line);
+    }
+
+    &__metrics {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3) var(--space-5);
+        align-items: flex-end;
+        margin-top: var(--space-4);
+    }
+
+    // the box only ever adds, so it stands at the far end of the row whether there are tabs or not
+    &__adder {
+        flex: 0 1 220px;
+        margin-bottom: var(--space-3);
+        margin-left: auto;
+    }
+
     &__foot {
         display: flex;
         flex-wrap: wrap;
         gap: var(--space-4);
         align-items: center;
         justify-content: space-between;
-    }
-
-    &__head {
-        padding: var(--space-4) var(--space-5);
-        border-bottom: var(--border-width) solid var(--line);
-    }
-
-    // the chips are the legend of the chart, so the box holding them is as wide as they need
-    &__picker {
-        flex: 1 1 320px;
-    }
-
-    &__foot {
         padding: 10px var(--space-5);
         font-size: var(--text-xs);
         color: var(--text-muted);
         border-top: var(--border-width) solid var(--line);
     }
 
+    // what the open tab counts, which is the one thing a chart cannot say about itself
+    &__about {
+        color: var(--text-body);
+    }
+
     &__count {
         font-family: var(--font-mono);
         font-variant-numeric: tabular-nums;
+        white-space: nowrap;
     }
 
     .chart-canvas {
@@ -148,10 +163,11 @@
     }
 }
 
-// In the panel head the field is not a field: the chips are what is in the chart, and what is left of
-// the box is the one dashed slot another line is added in. So the border moves off the control and
-// onto that slot, which is the only part of it that is an invitation.
-.chart-panel__picker.combobox {
+// In the panel head a field is not a field: what is in the chart is said by the chips next to it and by
+// the tabs under it, and what is left of the box is the one dashed slot something is added in. So the
+// border moves off the control and onto that slot, which is the only part of it that is an invitation.
+.chart-panel__picker.combobox,
+.chart-panel__adder.combobox {
     .combobox__control {
         padding: 0;
         background: none;
@@ -179,6 +195,31 @@
             border-color: var(--brand);
             box-shadow: var(--focus-ring);
         }
+    }
+}
+
+// The metric box is that slot and nothing else - no chips ever land in it, so it is as tall as what is
+// typed into it. Its menu is not: a row of it carries a name, the section it is printed under and the
+// sentence saying what it counts, because nobody knows what `llocByNof` is before reading that.
+.chart-panel__adder.combobox {
+    .combobox__control {
+        min-height: 0;
+    }
+
+    .combobox__input {
+        flex: 1 1 auto;
+    }
+
+    // wide enough for the longest name the catalog holds next to the section it is printed under -
+    // and where it still is not, the name wraps rather than ending in an ellipsis, since the name is
+    // the one thing the menu is read for
+    .combobox__menu {
+        left: auto;
+        width: min(480px, calc(100vw - 2 * var(--space-5)));
+    }
+
+    .combobox__name {
+        white-space: normal;
     }
 }
 
@@ -219,8 +260,8 @@
     }
 }
 
-// The tabs sit on the rail rather than under a heading - with a single line there is nothing to pick
-// and they are not rendered at all, which is what the rail is left holding.
+// The tabs sit on the rail rather than under a heading, and a chart of one line still has one of them:
+// with nothing to switch to it is not a choice but the name of whose release is being read.
 //
 // A chart of fifty lines is fifty tabs, and they scroll rather than wrap: the rail is one row, and the
 // controls sharing it belong on its right end whatever is to the left of them.
@@ -234,6 +275,10 @@
 
     .tab {
         flex: 0 0 auto;
+        // the rail under this row is the one `.release__rail` draws, so a tab does not have to reach
+        // a pixel past its own row to sit on it - and a row that scrolls sideways scrolls in both
+        // directions, so that one pixel is a scrollbar
+        margin-bottom: 0;
     }
 }
 

--- a/src/ComplexityReport/GraphData.php
+++ b/src/ComplexityReport/GraphData.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\ComplexityReport;
 
+use App\ComplexityReport\Metric\Measurement;
+use App\ComplexityReport\Metric\Metric;
 use App\Entity\Repository;
 use App\Entity\Tag;
 
@@ -11,8 +13,15 @@ final class GraphData implements \JsonSerializable
 {
     private const DATE_FORMAT = 'm-d-y';
 
-    public function __construct(private Repository $repository)
-    {
+    /**
+     * @param list<Metric> $metrics the numbers this line is asked for - a release was measured in
+     *                              sixty-two of them and a chart draws one or two, so what travels is
+     *                              what is drawn
+     */
+    public function __construct(
+        private Repository $repository,
+        private array $metrics,
+    ) {
     }
 
     /**
@@ -26,33 +35,37 @@ final class GraphData implements \JsonSerializable
     }
 
     /**
-     * `x` is what the chart plots, `date` and `loc` are what the release analysis below it reads.
+     * `x` is where a release sits on the time axis, `date` is what the release analysis prints, and
+     * `values` are the numbers it is drawn as, keyed by the slug they are picked under.
      *
-     * What is deliberately not in here is the measurement itself: sixty numbers per release would be most
-     * of what a chart of fifty repositories transfers, for a modal that is opened for one release at a
-     * time. Every release has one, so the panel does not need to be told - it fetches the output of the
-     * release somebody opens.
+     * What is deliberately not in here is the whole measurement: sixty-two numbers per release would be
+     * most of what a chart of fifty repositories transfers, for a panel that is read one release at a
+     * time. A release the reader opens is fetched with everything phploc counted; a release the chart
+     * only draws is worth the numbers it is drawn as.
      *
-     * @return list<array{name: string, x: string, date: string, y: float, loc: int}>
+     * @return list<array{name: string, x: string, date: string, values: array<string, float|int|null>}>
      */
     public function getTagData(): array
     {
-        return array_values(array_map(static function (Tag $tag) {
+        return array_values(array_map(function (Tag $tag) {
             return [
                 'name' => $tag->getName(),
                 'x' => $tag->getCreated()->format(self::DATE_FORMAT),
                 'date' => $tag->getCreated()->format('Y-m-d'),
-                'y' => round($tag->getAverageComplexity(), 2),
-                'loc' => $tag->getLinesOfCode(),
+                'values' => (new Measurement($tag->getMetrics()))->values($this->metrics),
             ];
         }, $this->repository->getTags()));
     }
 
     /**
-     * A line of the chart: what it is called, where it comes from and the releases it is drawn from.
-     * `url` and `stars` are what the release analysis says about the repository behind the line.
+     * A line of the chart: what it is called, where it comes from, which numbers it carries and the
+     * releases it is drawn from. `url` and `stars` are what the release analysis says about the
+     * repository behind the line.
      *
-     * @return array{name: string, url: string, stars: int, tags: list<array{name: string, x: string, date: string, y: float, loc: int}>, labels: list<string>}
+     * `metrics` is what was asked for, so the browser can tell a line it may draw from one it has to
+     * ask for another number for.
+     *
+     * @return array{name: string, url: string, stars: int, metrics: list<string>, tags: list<array{name: string, x: string, date: string, values: array<string, float|int|null>}>, labels: list<string>}
      */
     public function jsonSerialize(): array
     {
@@ -61,6 +74,7 @@ final class GraphData implements \JsonSerializable
             'name' => $this->repository->getName(),
             'url' => $this->repository->getUrl(),
             'stars' => $this->repository->getStars(),
+            'metrics' => array_map(static fn (Metric $metric) => $metric->value, $this->metrics),
             'tags' => $this->getTagData(),
             'labels' => $this->getLabels(),
         ];

--- a/src/ComplexityReport/Metric/Measurement.php
+++ b/src/ComplexityReport/Metric/Measurement.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Metric;
+
+/**
+ * A stored phploc measurement, read through the catalog.
+ *
+ * The array a release carries is what phploc returned, keyed the way phploc keys it. This is the one
+ * place that knows how to get a number out of it: what a metric is stored under, how far it is rounded,
+ * and what share of its whole it is - the percentages phploc prints behind half of its numbers are not
+ * stored anywhere either, they are the part over the whole, computed when the measurement is printed.
+ *
+ * Nothing here is a query. A measurement is read out of a release the report already loaded, so this is
+ * arithmetic over an array, and it is where the arithmetic of the report belongs: the browser draws
+ * what it is given.
+ */
+final readonly class Measurement
+{
+    /**
+     * @param array<string, float|int> $metrics as measured, see {@see \App\ComplexityReport\Analysis::$metrics}
+     */
+    public function __construct(private array $metrics)
+    {
+    }
+
+    /**
+     * The number, rounded to what the metric is written with - null when the measurement does not carry
+     * it, which is what a release measured by a phploc that counted something else would look like.
+     */
+    public function value(Metric $metric): int|float|null
+    {
+        $value = $this->metrics[$metric->source()] ?? null;
+
+        if (!is_numeric($value)) {
+            return null;
+        }
+
+        $decimals = $metric->decimals();
+
+        return 0 === $decimals ? (int) round((float) $value) : round((float) $value, $decimals);
+    }
+
+    /**
+     * What percentage of its whole this number is - `Static method calls` against all method calls -
+     * and null for a number that is not part of anything, or whose whole is zero.
+     */
+    public function share(Metric $metric): ?float
+    {
+        $whole = $metric->partOf();
+
+        if (null === $whole) {
+            return null;
+        }
+
+        $total = $this->value($whole);
+        $part = $this->value($metric);
+
+        if (null === $total || null === $part || 0.0 === (float) $total) {
+            return null;
+        }
+
+        return round(((float) $part / (float) $total) * 100, 2);
+    }
+
+    /**
+     * The values of the metrics asked for, keyed by slug - what a line of the chart is drawn from.
+     *
+     * @param list<Metric> $metrics
+     *
+     * @return array<string, float|int|null>
+     */
+    public function values(array $metrics): array
+    {
+        $values = [];
+
+        foreach ($metrics as $metric) {
+            $values[$metric->value] = $this->value($metric);
+        }
+
+        return $values;
+    }
+
+    /**
+     * The whole measurement interpreted: every number of the catalog with its share of its whole. This
+     * is what the release panel reads - sixty numbers for one release, which is why it is fetched for
+     * the release somebody opened rather than carried by a chart of hundreds of them.
+     *
+     * @return array{values: array<string, float|int|null>, shares: array<string, float>}
+     */
+    public function interpreted(): array
+    {
+        $shares = [];
+
+        foreach (Metric::cases() as $metric) {
+            $share = $this->share($metric);
+
+            if (null !== $share) {
+                $shares[$metric->value] = $share;
+            }
+        }
+
+        return ['values' => $this->values(Metric::cases()), 'shares' => $shares];
+    }
+}

--- a/src/ComplexityReport/Metric/Metric.php
+++ b/src/ComplexityReport/Metric/Metric.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Metric;
+
+/**
+ * What a release can be read in: the catalog of numbers the report draws, names and explains.
+ *
+ * A measurement is sixty-two numbers phploc counted and the report used to plot two of them. The other
+ * sixty were kept - they are what the raw output is printed from - but nothing said what they mean, so
+ * they were a blob. This is the blob read out: every number the report offers has a name, the section
+ * phploc prints it under, the whole it is a part of, and one line saying what it is worth.
+ *
+ * A metric is addressed by its **slug**, not by the phploc key behind it: the slug is what a chart is
+ * shared as (`?metrics=complexity,loc`), so it is written the way the number is spoken about, and
+ * `source()` is where it comes from. That is also why `complexity` is a slug of its own - the number the
+ * whole report is about is `classCcnAvg` in a phploc measurement, which is nothing to hand somebody as
+ * a link.
+ *
+ * Eight of the sixty-two are deliberately not here:
+ *
+ * - the five minimums (smallest class, shortest method, least methods per class, and the two smallest
+ *   complexities). A minimum is the floor of a codebase, and in this dataset the floor is an empty class
+ *   or a one-branch method in nearly every release measured - `classCcnMin` is 1 in 96% of the twenty
+ *   thousand releases the report carries. Charting it draws a straight line at 1 and says only that
+ *   somebody wrote a getter.
+ * - `testClasses` and `testMethods`, which are zero everywhere: tests are never counted into the report.
+ * - `ccnMethods`, the total method complexity, which is the same statement as the total complexity next
+ *   to it.
+ *
+ * They are all still in the measurement and still in the raw output - not being worth a chart is not the
+ * same as not being measured.
+ */
+enum Metric: string
+{
+    // --- Size ---------------------------------------------------------------------------------
+    case Directories = 'directories';
+    case Files = 'files';
+    case LinesOfCode = 'loc';
+    case CommentLines = 'comment-lines';
+    case NonCommentLines = 'code-lines';
+    case LogicalLines = 'logical-lines';
+    case ClassLines = 'class-lines';
+    case ClassLength = 'class-length';
+    case LongestClass = 'longest-class';
+    case MethodLength = 'method-length';
+    case LongestMethod = 'longest-method';
+    case MethodsPerClass = 'methods-per-class';
+    case MostMethodsPerClass = 'most-methods-per-class';
+    case FunctionLines = 'function-lines';
+    case FunctionLength = 'function-length';
+    case GlobalLines = 'global-lines';
+
+    // --- Cyclomatic complexity ----------------------------------------------------------------
+    case ComplexityPerLine = 'complexity-per-line';
+    case Complexity = 'complexity';
+    case MostComplexClass = 'most-complex-class';
+    case MethodComplexity = 'method-complexity';
+    case MostComplexMethod = 'most-complex-method';
+    case TotalComplexity = 'total-complexity';
+
+    // --- Dependencies -------------------------------------------------------------------------
+    case GlobalAccesses = 'global-accesses';
+    case GlobalConstantAccesses = 'global-constant-accesses';
+    case GlobalVariableAccesses = 'global-variable-accesses';
+    case SuperGlobalAccesses = 'super-global-accesses';
+    case AttributeAccesses = 'attribute-accesses';
+    case InstanceAttributeAccesses = 'instance-attribute-accesses';
+    case StaticAttributeAccesses = 'static-attribute-accesses';
+    case MethodCalls = 'method-calls';
+    case InstanceMethodCalls = 'instance-method-calls';
+    case StaticMethodCalls = 'static-method-calls';
+
+    // --- Structure ----------------------------------------------------------------------------
+    case Namespaces = 'namespaces';
+    case Interfaces = 'interfaces';
+    case Traits = 'traits';
+    case Classes = 'classes';
+    case AbstractClasses = 'abstract-classes';
+    case ConcreteClasses = 'concrete-classes';
+    case FinalClasses = 'final-classes';
+    case NonFinalClasses = 'non-final-classes';
+    case Methods = 'methods';
+    case NonStaticMethods = 'non-static-methods';
+    case StaticMethods = 'static-methods';
+    case PublicMethods = 'public-methods';
+    case ProtectedMethods = 'protected-methods';
+    case PrivateMethods = 'private-methods';
+    case Functions = 'functions';
+    case NamedFunctions = 'named-functions';
+    case AnonymousFunctions = 'anonymous-functions';
+    case Constants = 'constants';
+    case GlobalConstants = 'global-constants';
+    case ClassConstants = 'class-constants';
+    case PublicClassConstants = 'public-class-constants';
+    case NonPublicClassConstants = 'non-public-class-constants';
+
+    /**
+     * The metric a chart opens on: the report is about cyclomatic complexity, so nothing else can be
+     * what it draws when nobody said what to draw.
+     */
+    public static function default(): self
+    {
+        return self::Complexity;
+    }
+
+    /**
+     * The key this number is stored under in a phploc measurement.
+     */
+    public function source(): string
+    {
+        return match ($this) {
+            self::Directories => 'directories',
+            self::Files => 'files',
+            self::LinesOfCode => 'loc',
+            self::CommentLines => 'cloc',
+            self::NonCommentLines => 'ncloc',
+            self::LogicalLines => 'lloc',
+            self::ClassLines => 'llocClasses',
+            self::ClassLength => 'classLlocAvg',
+            self::LongestClass => 'classLlocMax',
+            self::MethodLength => 'methodLlocAvg',
+            self::LongestMethod => 'methodLlocMax',
+            self::MethodsPerClass => 'averageMethodsPerClass',
+            self::MostMethodsPerClass => 'maximumMethodsPerClass',
+            self::FunctionLines => 'llocFunctions',
+            self::FunctionLength => 'llocByNof',
+            self::GlobalLines => 'llocGlobal',
+            self::ComplexityPerLine => 'ccnByLloc',
+            self::Complexity => 'classCcnAvg',
+            self::MostComplexClass => 'classCcnMax',
+            self::MethodComplexity => 'methodCcnAvg',
+            self::MostComplexMethod => 'methodCcnMax',
+            self::TotalComplexity => 'ccn',
+            self::GlobalAccesses => 'globalAccesses',
+            self::GlobalConstantAccesses => 'globalConstantAccesses',
+            self::GlobalVariableAccesses => 'globalVariableAccesses',
+            self::SuperGlobalAccesses => 'superGlobalVariableAccesses',
+            self::AttributeAccesses => 'attributeAccesses',
+            self::InstanceAttributeAccesses => 'instanceAttributeAccesses',
+            self::StaticAttributeAccesses => 'staticAttributeAccesses',
+            self::MethodCalls => 'methodCalls',
+            self::InstanceMethodCalls => 'instanceMethodCalls',
+            self::StaticMethodCalls => 'staticMethodCalls',
+            self::Namespaces => 'namespaces',
+            self::Interfaces => 'interfaces',
+            self::Traits => 'traits',
+            self::Classes => 'classes',
+            self::AbstractClasses => 'abstractClasses',
+            self::ConcreteClasses => 'concreteClasses',
+            self::FinalClasses => 'finalClasses',
+            self::NonFinalClasses => 'nonFinalClasses',
+            self::Methods => 'methods',
+            self::NonStaticMethods => 'nonStaticMethods',
+            self::StaticMethods => 'staticMethods',
+            self::PublicMethods => 'publicMethods',
+            self::ProtectedMethods => 'protectedMethods',
+            self::PrivateMethods => 'privateMethods',
+            self::Functions => 'functions',
+            self::NamedFunctions => 'namedFunctions',
+            self::AnonymousFunctions => 'anonymousFunctions',
+            self::Constants => 'constants',
+            self::GlobalConstants => 'globalConstants',
+            self::ClassConstants => 'classConstants',
+            self::PublicClassConstants => 'publicClassConstants',
+            self::NonPublicClassConstants => 'nonPublicClassConstants',
+        };
+    }
+
+    /**
+     * What the number is called - phploc's own wording wherever it prints one, so the chart and the raw
+     * output name the same thing the same way.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Directories => 'Directories',
+            self::Files => 'Files',
+            self::LinesOfCode => 'Lines of code (LOC)',
+            self::CommentLines => 'Comment lines (CLOC)',
+            self::NonCommentLines => 'Non-comment lines (NCLOC)',
+            self::LogicalLines => 'Logical lines (LLOC)',
+            self::ClassLines => 'Logical lines in classes',
+            self::ClassLength => 'Average class length',
+            self::LongestClass => 'Longest class',
+            self::MethodLength => 'Average method length',
+            self::LongestMethod => 'Longest method',
+            self::MethodsPerClass => 'Average methods per class',
+            self::MostMethodsPerClass => 'Most methods in a class',
+            self::FunctionLines => 'Logical lines in functions',
+            self::FunctionLength => 'Average function length',
+            self::GlobalLines => 'Logical lines outside classes and functions',
+            self::ComplexityPerLine => 'Average complexity per logical line',
+            self::Complexity => 'Average complexity per class',
+            self::MostComplexClass => 'Most complex class',
+            self::MethodComplexity => 'Average complexity per method',
+            self::MostComplexMethod => 'Most complex method',
+            self::TotalComplexity => 'Total cyclomatic complexity',
+            self::GlobalAccesses => 'Global accesses',
+            self::GlobalConstantAccesses => 'Global constants read',
+            self::GlobalVariableAccesses => 'Global variables read',
+            self::SuperGlobalAccesses => 'Super-globals read',
+            self::AttributeAccesses => 'Attribute accesses',
+            self::InstanceAttributeAccesses => 'Non-static attribute accesses',
+            self::StaticAttributeAccesses => 'Static attribute accesses',
+            self::MethodCalls => 'Method calls',
+            self::InstanceMethodCalls => 'Non-static method calls',
+            self::StaticMethodCalls => 'Static method calls',
+            self::Namespaces => 'Namespaces',
+            self::Interfaces => 'Interfaces',
+            self::Traits => 'Traits',
+            self::Classes => 'Classes',
+            self::AbstractClasses => 'Abstract classes',
+            self::ConcreteClasses => 'Concrete classes',
+            self::FinalClasses => 'Final classes',
+            self::NonFinalClasses => 'Non-final classes',
+            self::Methods => 'Methods',
+            self::NonStaticMethods => 'Non-static methods',
+            self::StaticMethods => 'Static methods',
+            self::PublicMethods => 'Public methods',
+            self::ProtectedMethods => 'Protected methods',
+            self::PrivateMethods => 'Private methods',
+            self::Functions => 'Functions',
+            self::NamedFunctions => 'Named functions',
+            self::AnonymousFunctions => 'Anonymous functions',
+            self::Constants => 'Constants',
+            self::GlobalConstants => 'Global constants',
+            self::ClassConstants => 'Class constants',
+            self::PublicClassConstants => 'Public class constants',
+            self::NonPublicClassConstants => 'Non-public class constants',
+        };
+    }
+
+    /**
+     * What the number says, in one line. This is the whole point of the catalog: a measurement anybody
+     * can chart is worth nothing while the reader has to know what `llocByNof` was supposed to mean.
+     */
+    public function about(): string
+    {
+        return match ($this) {
+            self::Directories => 'Directories the source files sit in.',
+            self::Files => 'PHP files the measurement read.',
+            self::LinesOfCode => 'Every line of every file, comments and blank lines included.',
+            self::CommentLines => 'Lines that are comments - against the lines of code, how much of the source is prose.',
+            self::NonCommentLines => 'Everything that is not a comment.',
+            self::LogicalLines => 'Statements rather than lines: what the code does, independent of how it is formatted.',
+            self::ClassLines => 'Statements that stand in a class.',
+            self::ClassLength => 'Statements per class - a codebase of few long classes reads differently than one of many short ones.',
+            self::LongestClass => 'The longest class of the release, in statements.',
+            self::MethodLength => 'Statements per method.',
+            self::LongestMethod => 'The longest method of the release, in statements.',
+            self::MethodsPerClass => 'Methods per class.',
+            self::MostMethodsPerClass => 'The widest class of the release, in methods.',
+            self::FunctionLines => 'Statements that stand in a function rather than a class.',
+            self::FunctionLength => 'Statements per function.',
+            self::GlobalLines => 'Statements in neither a class nor a function - the script-shaped part of a library.',
+            self::ComplexityPerLine => 'Branches per statement: how dense the decisions are, whatever the size.',
+            self::Complexity => 'Branches per class, averaged - the number the whole report is about.',
+            self::MostComplexClass => 'The most branching class of the release; one god class raises this and nothing else.',
+            self::MethodComplexity => 'Branches per method - closer to what a reader of a single method meets.',
+            self::MostComplexMethod => 'The most branching method of the release.',
+            self::TotalComplexity => 'Every branch in the codebase added up - it grows with the code, so read it next to the size.',
+            self::GlobalAccesses => 'Reads of global state: constants, variables and super-globals together.',
+            self::GlobalConstantAccesses => 'Reads of a global constant.',
+            self::GlobalVariableAccesses => 'Reads of a global variable.',
+            self::SuperGlobalAccesses => 'Reads of $_GET, $_POST and their siblings - request state straight out of the language.',
+            self::AttributeAccesses => 'Reads and writes of object or class properties.',
+            self::InstanceAttributeAccesses => 'Properties reached through an object.',
+            self::StaticAttributeAccesses => 'Properties reached through a class - shared state that no instance owns.',
+            self::MethodCalls => 'Method calls, whichever way they are made.',
+            self::InstanceMethodCalls => 'Calls on an object.',
+            self::StaticMethodCalls => 'Calls on a class, which is a dependency nothing can substitute.',
+            self::Namespaces => 'Namespaces the code is spread over.',
+            self::Interfaces => 'Interfaces declared.',
+            self::Traits => 'Traits declared.',
+            self::Classes => 'Classes declared, abstract and concrete.',
+            self::AbstractClasses => 'Classes that cannot be instantiated.',
+            self::ConcreteClasses => 'Classes that can.',
+            self::FinalClasses => 'Concrete classes closed against extension.',
+            self::NonFinalClasses => 'Concrete classes left open to extension.',
+            self::Methods => 'Methods declared on all of those classes.',
+            self::NonStaticMethods => 'Methods that need an instance.',
+            self::StaticMethods => 'Methods that do not.',
+            self::PublicMethods => 'Methods anyone may call - the surface the library is used through.',
+            self::ProtectedMethods => 'Methods only the class and what extends it may call.',
+            self::PrivateMethods => 'Methods only the class itself may call.',
+            self::Functions => 'Functions outside classes, named and anonymous.',
+            self::NamedFunctions => 'Functions with a name.',
+            self::AnonymousFunctions => 'Closures and arrow functions.',
+            self::Constants => 'Constants declared, global and on classes.',
+            self::GlobalConstants => 'Constants outside a class.',
+            self::ClassConstants => 'Constants on a class.',
+            self::PublicClassConstants => 'Class constants anyone may read.',
+            self::NonPublicClassConstants => 'Class constants that stay inside.',
+        };
+    }
+
+    /**
+     * The section a metric is printed under, which is the section it is picked from.
+     */
+    public function group(): MetricGroup
+    {
+        return match ($this) {
+            self::Directories, self::Files, self::LinesOfCode, self::CommentLines, self::NonCommentLines,
+            self::LogicalLines, self::ClassLines, self::ClassLength, self::LongestClass, self::MethodLength,
+            self::LongestMethod, self::MethodsPerClass, self::MostMethodsPerClass, self::FunctionLines,
+            self::FunctionLength, self::GlobalLines => MetricGroup::Size,
+            self::ComplexityPerLine, self::Complexity, self::MostComplexClass, self::MethodComplexity,
+            self::MostComplexMethod, self::TotalComplexity => MetricGroup::Complexity,
+            self::GlobalAccesses, self::GlobalConstantAccesses, self::GlobalVariableAccesses,
+            self::SuperGlobalAccesses, self::AttributeAccesses, self::InstanceAttributeAccesses,
+            self::StaticAttributeAccesses, self::MethodCalls, self::InstanceMethodCalls,
+            self::StaticMethodCalls => MetricGroup::Dependencies,
+            default => MetricGroup::Structure,
+        };
+    }
+
+    /**
+     * The whole this number is a part of, if it is one - `Static method calls` are a share of
+     * `Method calls`, the way phploc prints them.
+     *
+     * It is what a percentage is read against, and it is what the interpreted measurement is indented
+     * by: a part stands under its whole, which is the shape of phploc's own output.
+     */
+    public function partOf(): ?self
+    {
+        return match ($this) {
+            self::CommentLines, self::NonCommentLines, self::LogicalLines => self::LinesOfCode,
+            self::ClassLines, self::FunctionLines, self::GlobalLines => self::LogicalLines,
+            self::GlobalConstantAccesses, self::GlobalVariableAccesses, self::SuperGlobalAccesses => self::GlobalAccesses,
+            self::InstanceAttributeAccesses, self::StaticAttributeAccesses => self::AttributeAccesses,
+            self::InstanceMethodCalls, self::StaticMethodCalls => self::MethodCalls,
+            self::AbstractClasses, self::ConcreteClasses => self::Classes,
+            self::FinalClasses, self::NonFinalClasses => self::ConcreteClasses,
+            self::NonStaticMethods, self::StaticMethods, self::PublicMethods, self::ProtectedMethods,
+            self::PrivateMethods => self::Methods,
+            self::NamedFunctions, self::AnonymousFunctions => self::Functions,
+            self::GlobalConstants, self::ClassConstants => self::Constants,
+            self::PublicClassConstants, self::NonPublicClassConstants => self::ClassConstants,
+            default => null,
+        };
+    }
+
+    /**
+     * How many decimals the number is written with, which is also how far it is rounded before it is
+     * sent anywhere: a count is a whole thing that was counted, and no chart of this report is read to
+     * the ten-thousandth of a class.
+     *
+     * The average complexity per statement is the one number small enough to need a third: it runs
+     * between 0.05 and 0.30 across the whole report, so two decimals would draw it in steps.
+     */
+    public function decimals(): int
+    {
+        return match ($this) {
+            self::ComplexityPerLine => 3,
+            self::ClassLength, self::MethodLength, self::MethodsPerClass, self::FunctionLength,
+            self::Complexity, self::MethodComplexity => 2,
+            default => 0,
+        };
+    }
+
+    /**
+     * Whether falling is an improvement - see {@see MetricDirection}.
+     */
+    public function direction(): MetricDirection
+    {
+        return match ($this) {
+            self::ComplexityPerLine, self::Complexity, self::MostComplexClass, self::MethodComplexity,
+            self::MostComplexMethod => MetricDirection::Lower,
+            default => MetricDirection::Neutral,
+        };
+    }
+
+    /**
+     * Whether the number is read against the risk bands of {@see \App\ComplexityReport\ComplexityLevel}.
+     *
+     * Only the averages are: the bands are written for an average cyclomatic complexity, and a maximum
+     * is one class - the most complex class of a library is over fifty in most of the report, which
+     * would paint every library red for a single outlier.
+     */
+    public function carriesLevel(): bool
+    {
+        return self::Complexity === $this || self::MethodComplexity === $this;
+    }
+}

--- a/src/ComplexityReport/Metric/MetricCatalog.php
+++ b/src/ComplexityReport/Metric/MetricCatalog.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Metric;
+
+/**
+ * The catalog, handed to the browser.
+ *
+ * The chart names metrics, formats their numbers, decides which change is worth a colour and indents a
+ * part under its whole - all of which is written down once, in {@see Metric}. So the page renders the
+ * catalog into the chart rather than the chart carrying a copy of it: the two numbers the switch used
+ * to hold were small enough to mirror in javascript, fifty-four with a sentence each are not, and a
+ * mirror is only ever as true as the day it was written.
+ */
+final readonly class MetricCatalog implements \JsonSerializable
+{
+    /**
+     * @return list<array{slug: string, label: string, about: string, group: string, groupLabel: string, groupAbout: string, default: bool, decimals: int, direction: string, level: bool, partOf: string|null, depth: int}>
+     */
+    public function jsonSerialize(): array
+    {
+        return array_values(array_map(static function (Metric $metric) {
+            $whole = $metric->partOf();
+
+            return [
+                'slug' => $metric->value,
+                'label' => $metric->label(),
+                'about' => $metric->about(),
+                'group' => $metric->group()->value,
+                'groupLabel' => $metric->group()->label(),
+                'groupAbout' => $metric->group()->about(),
+                // the metric a chart is drawn as while its address says nothing about it
+                'default' => Metric::default() === $metric,
+                'decimals' => $metric->decimals(),
+                'direction' => $metric->direction()->value,
+                'level' => $metric->carriesLevel(),
+                'partOf' => $whole?->value,
+                // how deep the number stands under its section, the way phploc indents its output
+                'depth' => self::depth($metric),
+            ];
+        }, Metric::cases()));
+    }
+
+    private static function depth(Metric $metric): int
+    {
+        $depth = 0;
+
+        while (null !== $metric = $metric->partOf()) {
+            ++$depth;
+        }
+
+        return $depth;
+    }
+}

--- a/src/ComplexityReport/Metric/MetricDirection.php
+++ b/src/ComplexityReport/Metric/MetricDirection.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Metric;
+
+/**
+ * Whether a change in a metric is a statement or just a change.
+ *
+ * The report has an opinion about complexity: a codebase whose average complexity falls got easier to
+ * test, and one whose average rose got harder. It has none about size - a library that grew by twenty
+ * thousand lines did not thereby get better or worse, it got bigger, and saying otherwise would make
+ * every release of every growing project look like a regression.
+ *
+ * So only the metrics that carry a risk are coloured; everything else is shown as the signed number it
+ * is.
+ */
+enum MetricDirection: string
+{
+    /**
+     * A change worth no colour - more classes are not better classes.
+     */
+    case Neutral = 'neutral';
+
+    /**
+     * Falling is the improvement: the complexities, where less branching is less risk.
+     */
+    case Lower = 'lower';
+}

--- a/src/ComplexityReport/Metric/MetricGroup.php
+++ b/src/ComplexityReport/Metric/MetricGroup.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Metric;
+
+/**
+ * The sections a measurement is read in - phploc's own, in phploc's order.
+ *
+ * The report does not invent a grouping of its own: a measurement is printed under these four headings
+ * by the tool that took it, so a number stands where whoever ran phploc would look for it, and the
+ * interpreted measurement and the raw output are the same report twice.
+ */
+enum MetricGroup: string
+{
+    case Size = 'size';
+    case Complexity = 'complexity';
+    case Dependencies = 'dependencies';
+    case Structure = 'structure';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Size => 'Size',
+            self::Complexity => 'Cyclomatic complexity',
+            self::Dependencies => 'Dependencies',
+            self::Structure => 'Structure',
+        };
+    }
+
+    /**
+     * What the section is about, in one line - the sentence the report adds to phploc's heading.
+     */
+    public function about(): string
+    {
+        return match ($this) {
+            self::Size => 'How much code there is, counted as lines and as statements.',
+            self::Complexity => 'How many branches that code carries - the report is about this one.',
+            self::Dependencies => 'What the code reaches for: globals, attributes, method calls.',
+            self::Structure => 'What it is built from: namespaces, classes, methods, functions, constants.',
+        };
+    }
+
+    /**
+     * The metrics of this section, in the order phploc prints them.
+     *
+     * @return list<Metric>
+     */
+    public function metrics(): array
+    {
+        return array_values(array_filter(Metric::cases(), fn (Metric $metric) => $this === $metric->group()));
+    }
+}

--- a/src/ComplexityReport/Metric/MetricSelection.php
+++ b/src/ComplexityReport/Metric/MetricSelection.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ComplexityReport\Metric;
+
+/**
+ * What the chart can be read in: `?metrics=complexity,loc` - one tab per metric, in the order they were
+ * asked for, and `?metric=loc` says which of them is the one being looked at.
+ *
+ * The rules are the ones the repositories of a chart already follow, because it is the same query
+ * string and the same reader: a metric is named by the slug it is spoken about under, one is enough
+ * however often it is repeated, and anything that is not a metric of the report is dropped rather than
+ * answered with an error. What is left of an empty selection is the metric the report is about.
+ *
+ * `?metric=` is the switch the chart grew out of, and it still means what it meant: the number the
+ * chart is drawn as. It only says less than it used to - which of the tabs is open, rather than that
+ * there are two of them - so the links that were handed out under it still open what they named.
+ */
+final readonly class MetricSelection
+{
+    /**
+     * @param list<Metric> $picked
+     */
+    private function __construct(private array $picked, private Metric $active)
+    {
+    }
+
+    /**
+     * @param string $metrics what `?metrics=` was given as
+     * @param string $legacy  what `?metric=` was given as
+     */
+    public static function fromInput(string $metrics, string $legacy = ''): self
+    {
+        $picked = self::parse($metrics);
+        $shown = self::parse($legacy);
+
+        // a chart addressed only by the metric it is drawn as is a chart of that one metric
+        if ([] === $picked) {
+            $picked = $shown;
+        }
+
+        if ([] === $picked) {
+            $picked = [Metric::default()];
+        }
+
+        // the tab that is open, which is the first one unless the address names another of them
+        $active = array_values(array_filter($shown, static fn (Metric $metric) => \in_array($metric, $picked, true)));
+
+        return new self($picked, $active[0] ?? $picked[0]);
+    }
+
+    public static function of(Metric ...$metrics): self
+    {
+        $picked = [] === $metrics ? [Metric::default()] : array_values($metrics);
+
+        return new self($picked, $picked[0]);
+    }
+
+    /**
+     * The metrics the chart can be read in, in the order it tabs them - all of them travel with the
+     * page, because switching between two numbers of a release the browser already has is a redraw and
+     * must not be a request.
+     *
+     * @return list<Metric>
+     */
+    public function getPicked(): array
+    {
+        return $this->picked;
+    }
+
+    /**
+     * The one the chart opens on.
+     */
+    public function getActive(): Metric
+    {
+        return $this->active;
+    }
+
+    public function has(Metric $metric): bool
+    {
+        return \in_array($metric, $this->picked, true);
+    }
+
+    /**
+     * Everything that can be drawn, what is drawn first. The picked ones lead in the order they are
+     * stacked, because the select behind the box is the state and reports what is selected in the order
+     * it stands in - the same reason the repositories of a chart lead their own list.
+     *
+     * @return list<Metric>
+     */
+    public function getOptions(): array
+    {
+        $rest = array_filter(Metric::cases(), fn (Metric $metric) => !$this->has($metric));
+
+        return array_merge($this->picked, array_values($rest));
+    }
+
+    /**
+     * What the chart is drawn as, for the query string it is shared as.
+     *
+     * @return list<string>
+     */
+    public function getSlugs(): array
+    {
+        return array_map(static fn (Metric $metric) => $metric->value, $this->picked);
+    }
+
+    /**
+     * Whether this is the chart nobody said anything about - the report is about complexity, so that
+     * chart carries no metric in its address at all.
+     */
+    public function isDefault(): bool
+    {
+        return [Metric::default()] === $this->picked;
+    }
+
+    /**
+     * The tabs a chart carries are its address; which one is open is only written down when it is not
+     * the one a reader would land on anyway.
+     */
+    public function isFirstActive(): bool
+    {
+        return $this->active === $this->picked[0];
+    }
+
+    /**
+     * @return list<Metric>
+     */
+    private static function parse(string $input): array
+    {
+        $picked = [];
+
+        foreach (explode(',', $input) as $slug) {
+            $metric = Metric::tryFrom(mb_strtolower(trim($slug)));
+
+            // one line per metric: a chart of complexity and complexity is a chart of complexity
+            if (null !== $metric && !\in_array($metric, $picked, true)) {
+                $picked[] = $metric;
+            }
+        }
+
+        return $picked;
+    }
+}

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -7,6 +7,10 @@ namespace App\Controller;
 use App\ComplexityReport\Activity;
 use App\ComplexityReport\ChartSelection;
 use App\ComplexityReport\Exception\SubmissionFailed;
+use App\ComplexityReport\Metric\Measurement;
+use App\ComplexityReport\Metric\Metric;
+use App\ComplexityReport\Metric\MetricCatalog;
+use App\ComplexityReport\Metric\MetricSelection;
 use App\ComplexityReport\PhplocReport;
 use App\ComplexityReport\Ranking;
 use App\ComplexityReport\RankingLoader;
@@ -182,6 +186,9 @@ final class ReportController extends AbstractController
             'selection' => [] === $selected
                 ? ChartSelection::mostStarred($analysed, self::CHART_DEFAULT)
                 : ChartSelection::of($selected, $analysed),
+            'metrics' => $this->selectedMetrics($request),
+            // what every number of the report is called and worth, rendered once into the page
+            'catalog' => new MetricCatalog(),
         ]);
     }
 
@@ -220,13 +227,54 @@ final class ReportController extends AbstractController
      * rendered with, so a line picked later reads the same as one the page opened on. A repository is
      * addressed the way github.com addresses it, and that slug is the whole route - so the select box
      * can request it relative to the page it is on, which keeps working under a deployed sub path.
+     *
+     * `?metrics=` says which numbers the line carries, the same way it says it on the chart: a line is
+     * asked for again when the chart is drawn as something the browser does not have yet.
      */
     #[Route('{name}', name: 'repository', requirements: ['name' => '[^/]+/[^/]+'], methods: 'GET', priority: -2)]
-    public function repository(string $name, RepositoryRepository $repositories): JsonResponse
+    public function repository(string $name, Request $request, RepositoryRepository $repositories): JsonResponse
     {
         $repository = $repositories->findBySlug($name) ?? throw $this->createNotFoundException();
 
-        return new JsonResponse($repository->asGraph());
+        return new JsonResponse($repository->asGraph($this->selectedMetrics($request)->getPicked()));
+    }
+
+    /**
+     * One release, interpreted: every number phploc counted for it, named and put in the section it
+     * belongs to, next to the release before it so each of them can be read as a change.
+     *
+     * It is the same measurement the route below prints as phploc prints it - this is the report's
+     * reading of it, and the reason the sixty-two numbers are worth storing at all. Like the raw
+     * output it hangs under the release and is fetched when somebody opens one, because that is how a
+     * measurement is read: one at a time, while the chart above it holds hundreds.
+     */
+    #[Route('{name}/{tag}/metrics', name: 'measurement', requirements: ['name' => '[^/]+/[^/]+', 'tag' => '.+'], methods: 'GET', priority: -2)]
+    public function measurement(
+        string $name,
+        string $tag,
+        RepositoryRepository $repositories,
+        TagRepository $tags,
+    ): JsonResponse {
+        $repository = $repositories->findBySlug($name) ?? throw $this->createNotFoundException();
+        $release = $tags->findOneBy(['repository' => $repository, 'name' => $tag])
+            ?? throw $this->createNotFoundException();
+        $previous = $tags->findPrevious($release);
+
+        $response = new JsonResponse([
+            'name' => $release->getName(),
+            'date' => $release->getCreated()->format('Y-m-d'),
+            ...(new Measurement($release->getMetrics()))->interpreted(),
+            'previous' => null === $previous ? null : [
+                'name' => $previous->getName(),
+                'values' => (new Measurement($previous->getMetrics()))->values(Metric::cases()),
+            ],
+        ]);
+
+        // what a tag measured as does not change again - but the release before it is one a backfill
+        // can still put in front of it, so this is not the day the raw output is cached for
+        $response->setPublic()->setMaxAge(3600);
+
+        return $response;
     }
 
     /**
@@ -284,6 +332,19 @@ final class ReportController extends AbstractController
             'chart',
             ['repositories' => $repository->getName()],
             Response::HTTP_SEE_OTHER,
+        );
+    }
+
+    /**
+     * What `?metrics=complexity,loc` asks the chart to be drawn as - one panel per metric, in the order
+     * they were named. `?metric=` is the switch between two numbers this grew out of, and the links
+     * that were handed out under it still say what they meant.
+     */
+    private function selectedMetrics(Request $request): MetricSelection
+    {
+        return MetricSelection::fromInput(
+            $request->query->getString('metrics'),
+            $request->query->getString('metric'),
         );
     }
 

--- a/src/Entity/Repository.php
+++ b/src/Entity/Repository.php
@@ -8,6 +8,7 @@ use App\ComplexityReport\Analysis;
 use App\ComplexityReport\GitHub\RepositoryData;
 use App\ComplexityReport\GitTag;
 use App\ComplexityReport\GraphData;
+use App\ComplexityReport\Metric\Metric;
 use App\Repository\RepositoryRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -182,8 +183,13 @@ class Repository
         $this->analysed = new \DateTimeImmutable();
     }
 
-    public function asGraph(): GraphData
+    /**
+     * The repository as a line of the chart, drawn in the numbers it was asked for.
+     *
+     * @param list<Metric> $metrics
+     */
+    public function asGraph(array $metrics): GraphData
     {
-        return new GraphData($this);
+        return new GraphData($this, $metrics);
     }
 }

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -119,6 +119,29 @@ final class TagRepository extends ServiceEntityRepository
         return $tags;
     }
 
+    /**
+     * The release before this one, in the order the report reads releases: by the day they were tagged,
+     * and by name where a repository tagged two on the same day - the same order a chart draws them in,
+     * so "compared to the previous release" means the point to the left of it.
+     */
+    public function findPrevious(Tag $tag): ?Tag
+    {
+        /** @var ?Tag $previous */
+        $previous = $this->createQueryBuilder('t')
+            ->andWhere('t.repository = :repository')
+            ->andWhere('t.created < :created OR (t.created = :created AND t.name < :name)')
+            ->setParameter('repository', $tag->getRepository())
+            ->setParameter('created', $tag->getCreated())
+            ->setParameter('name', $tag->getName())
+            ->orderBy('t.created', 'DESC')
+            ->addOrderBy('t.name', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $previous;
+    }
+
     public function getLinesOfCodeSum(): int
     {
         $query = $this->createQueryBuilder('t')

--- a/templates/about.html.twig
+++ b/templates/about.html.twig
@@ -24,9 +24,9 @@
                     Anyone submits a repository, a worker clones it and checks out every major and minor
                     release, and
                     <a href="https://github.com/sebastianbergmann/phploc" target="_blank" rel="noreferrer">phploc</a>
-                    reads every <code>.php</code> file of it: lines of code, and the average cyclomatic
-                    complexity of a class. The clone is deleted, the numbers stay. Every night the report
-                    asks github.com what it is missing.
+                    reads every <code>.php</code> file of it and counts sixty-two numbers, the average
+                    cyclomatic complexity of a class among them. The clone is deleted, the numbers stay.
+                    Every night the report asks github.com what it is missing.
                 </p>
             </section>
             <section class="about__section">
@@ -61,8 +61,9 @@
                         and minor releases are measured (<code>5.4</code>, <code>5.4.0</code>) - patch
                         releases and pre-releases (anything carrying a <code>-</code>) are skipped, as are
                         a handful of releases whose date git cannot tell straight. On every checkout phploc
-                        reads every <code>.php</code> file of the working copy and leaves two numbers
-                        behind, dated by the last commit that tag points at.
+                        reads every <code>.php</code> file of the working copy and leaves its whole
+                        measurement behind - sixty-two numbers, dated by the last commit that tag points
+                        at, and every one of them can be drawn over the years.
                     </p>
                     <p>
                         From then on the report keeps itself current: every night it refreshes stars and

--- a/templates/chart.html.twig
+++ b/templates/chart.html.twig
@@ -20,7 +20,8 @@
      #}
     <main class="page">
         <div class="wrap page__body" data-controller="chart"
-             data-repositories="{{ series|map(repository => repository.asGraph)|json_encode|e('html_attr') }}">
+             data-repositories="{{ series|map(repository => repository.asGraph(metrics.picked))|json_encode|e('html_attr') }}"
+             data-catalog="{{ catalog|json_encode|e('html_attr') }}">
             <h1 class="visually-hidden">
                 <span data-chart-target="headline">{{ selection.headline }}</span>
                 <a data-chart-target="headlineLink"
@@ -113,10 +114,11 @@
 
                     <div class="panel chart-panel">
                         {#
-                         # What the chart is drawn from and what it draws it as, on the top edge of the
-                         # panel it does both in. The chips are the lines - each one in the colour of its
-                         # series, which is what a legend under the chart used to say - and the field
-                         # after them is where another one is added.
+                         # What the chart is drawn from and what it is read as, both on the top edge of
+                         # the panel it does them in. The chips are the lines - each one in the colour of
+                         # its series, which is what a legend under the chart used to say - and under
+                         # them stand the numbers those same lines can be drawn as, on the hairline the
+                         # chart hangs under.
                          #}
                         <div class="chart-panel__head">
                             <div class="combobox chart-panel__picker">
@@ -137,22 +139,47 @@
                             </div>
 
                             {#
-                             # What the same lines are drawn as. A release is measured in two numbers and
-                             # the report is about one of them, so complexity is what the chart opens on -
-                             # but reading a codebase growing under a complexity that holds is a different
-                             # statement than either number alone.
+                             # What the same lines are read as. A second metric is a tab, not a second
+                             # axis and not a second chart: colour already says which repository a line
+                             # belongs to and cannot also say which number it is, and two scales in one
+                             # frame let a crossing look like a statement when what crossed was the
+                             # scaling. Drawn one at a time in the same frame - same place, same width,
+                             # same years - two metrics are compared by switching between them.
+                             #
+                             # So the tabs stand on the rail the chart hangs under, and the box next to
+                             # them only ever adds: a metric is switched to and taken out again on its
+                             # own tab, and a second list of the same names would say it twice.
                              #}
-                            <div class="chart-metrics" role="tablist" aria-label="What the chart draws">
-                                <button type="button" class="metric-switch" role="tab" aria-selected="true"
-                                        aria-controls="chart-canvas" data-metric="complexity"
-                                        data-chart-target="metric" data-action="chart#selectMetric">
-                                    Ø complexity
-                                </button>
-                                <button type="button" class="metric-switch" role="tab" aria-selected="false"
-                                        aria-controls="chart-canvas" data-metric="loc"
-                                        data-chart-target="metric" data-action="chart#selectMetric">
-                                    Lines of code
-                                </button>
+                            <div class="chart-panel__metrics" {{ stimulus_controller('metric-picker') }}>
+                                <select name="metrics[]" multiple="multiple" hidden
+                                        data-chart-target="metrics" data-metric-picker-target="select"
+                                        data-active="{{ metrics.active.value }}"
+                                        data-action="change->chart#remetric change->metric-picker#refresh">
+                                    {% for metric in metrics.options %}
+                                        <option value="{{ metric.value }}" {{ metrics.has(metric) ? 'selected="selected"' }}
+                                                data-group="{{ metric.group.label }}"
+                                                data-about="{{ metric.about }}">{{ metric.label }}</option>
+                                    {% endfor %}
+                                </select>
+
+                                <div class="tabs tabs--metrics" role="tablist" aria-label="What the chart draws"
+                                     data-chart-target="metricTabs"></div>
+
+                                <div class="combobox chart-panel__adder">
+                                    <div class="combobox__control" data-action="click->metric-picker#focus">
+                                        <input type="text" class="combobox__input"
+                                               placeholder="+ add a metric"
+                                               aria-label="Metrics this chart can be read in"
+                                               autocomplete="off" autocapitalize="off" spellcheck="false"
+                                               role="combobox" aria-expanded="false" aria-autocomplete="list"
+                                               aria-controls="metric-suggestions"
+                                               data-metric-picker-target="input"
+                                               data-action="input->metric-picker#query focus->metric-picker#query keydown->metric-picker#navigate blur->metric-picker#close">
+                                    </div>
+                                    <ul class="combobox__menu" id="metric-suggestions" role="listbox"
+                                        aria-label="Everything phploc counts"
+                                        data-metric-picker-target="menu" hidden></ul>
+                                </div>
                             </div>
                         </div>
 
@@ -169,9 +196,12 @@
                             </button>
                         </div>
 
-                        {# what a point is, and how much of the report is on this one #}
+                        {# what the open tab counts, what a point is, and how much of the report is on this one #}
                         <div class="chart-panel__foot">
-                            <span>Scroll to zoom, drag to pan, click a release to read it below.</span>
+                            <span>
+                                <span class="chart-panel__about" data-chart-target="metricAbout"></span>
+                                Scroll to zoom, drag to pan, click a release to read it below.
+                            </span>
                             <span class="chart-panel__count" data-chart-target="count">
                                 {{ series|length }} {{ series|length == 1 ? 'repository' : 'repositories' }} ·
                                 {{ selection.releaseCount|number_format }}
@@ -203,9 +233,9 @@
                             <select class="release-select" aria-label="Release"
                                     data-chart-target="releaseSelect" data-action="chart#selectRelease"></select>
                             {#
-                             # The panel below is the handful of numbers the report has an opinion about;
-                             # a phploc run counts sixty. The rest is not summarised anywhere, it is shown
-                             # as phploc printed it.
+                             # The panel below is the release read in what the chart draws, and under it
+                             # every other number of the measurement. This is the same measurement once
+                             # more, printed rather than read - as phploc printed it.
                              #}
                             <button type="button" class="btn btn--secondary" data-action="chart#openRaw">
                                 <i class="fas fa-terminal"></i> Raw output
@@ -214,14 +244,30 @@
                     </div>
 
                     {#
-                     # What the release being read comes down to, before the panel spelling it out: where
-                     # it stands, what it did against the release before it, how large it is, and how much
-                     # of the repository has been measured.
+                     # What the release being read comes down to, above the panel spelling it out: where it
+                     # stands in the number the chart is open on, what it did against the release before it
+                     # and since the first one, and how much of the repository has been measured.
                      #}
                     <div class="headline-figures" data-chart-target="headlineFigures"></div>
 
                     <div class="panel panel--pad-lg" role="tabpanel" data-chart-target="releasePanel">
                         <div class="analysis" data-chart-target="analysis"></div>
+
+                        {#
+                         # The panel above is the release in the numbers the chart draws; this is the
+                         # answer to "and what else was measured" - every number of the catalog, in the
+                         # sections phploc prints them under, each with its share of the whole it is part
+                         # of and its change since the release before. It is folded away because it is
+                         # fifty-four numbers under the three somebody came for, and fetched when it is
+                         # opened rather than carried by a page that holds hundreds of releases.
+                         #}
+                        <div class="measurement">
+                            <button type="button" class="measurement__toggle" aria-expanded="false"
+                                    data-chart-target="measurementToggle" data-action="chart#toggleMeasurement">
+                                <i class="fas fa-chevron-right"></i> Everything phploc counted
+                            </button>
+                            <div class="measurement__body" data-chart-target="measurement" hidden></div>
+                        </div>
                     </div>
 
                     {#

--- a/tests/ComplexityReport/Metric/MeasurementTest.php
+++ b/tests/ComplexityReport/Metric/MeasurementTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\ComplexityReport\Metric;
+
+use App\ComplexityReport\Metric\Measurement;
+use App\ComplexityReport\Metric\Metric;
+use PHPUnit\Framework\TestCase;
+
+final class MeasurementTest extends TestCase
+{
+    public function testACountIsReadAsAWholeNumber(): void
+    {
+        $measurement = new Measurement(['loc' => 44913, 'classes' => 448]);
+
+        self::assertSame(44913, $measurement->value(Metric::LinesOfCode));
+        self::assertSame(448, $measurement->value(Metric::Classes));
+    }
+
+    /**
+     * The report is read to two decimals, which is where its trends live: 4.81 and 4.80 are a release
+     * that got simpler, and rounding either to 5 is the same report as no report.
+     */
+    public function testAnAverageIsReadToTheDecimalsItIsWrittenWith(): void
+    {
+        $measurement = new Measurement(['classCcnAvg' => 4.8056768558951966, 'ccnByLloc' => 0.1429035137547675]);
+
+        self::assertSame(4.81, $measurement->value(Metric::Complexity));
+        // the one number small enough to need a third decimal
+        self::assertSame(0.143, $measurement->value(Metric::ComplexityPerLine));
+    }
+
+    /**
+     * A release measured by something that counted less than phploc counts is a dash in the report, not
+     * a zero: a codebase with no classes at all is a measurement of 0, and there is a difference.
+     */
+    public function testANumberTheMeasurementDoesNotCarryIsNothing(): void
+    {
+        $measurement = new Measurement(['loc' => 100]);
+
+        self::assertNull($measurement->value(Metric::Classes));
+        self::assertNull($measurement->share(Metric::CommentLines));
+    }
+
+    public function testAPartIsReadAsAShareOfItsWhole(): void
+    {
+        $measurement = new Measurement(['loc' => 44913, 'cloc' => 11835]);
+
+        self::assertSame(26.35, $measurement->share(Metric::CommentLines));
+    }
+
+    public function testAWholeIsAShareOfNothing(): void
+    {
+        $measurement = new Measurement(['loc' => 44913, 'cloc' => 11835]);
+
+        self::assertNull($measurement->share(Metric::LinesOfCode));
+    }
+
+    /**
+     * Half the report is a percentage of something that can be zero - a release without a single
+     * function has no share of named ones, and dividing by it would be an error rather than a report.
+     */
+    public function testNothingIsNoShareOfNothing(): void
+    {
+        $measurement = new Measurement(['functions' => 0, 'namedFunctions' => 0]);
+
+        self::assertNull($measurement->share(Metric::NamedFunctions));
+    }
+
+    public function testALineOfTheChartCarriesOnlyTheNumbersItIsDrawnAs(): void
+    {
+        $measurement = new Measurement(['loc' => 44913, 'classCcnAvg' => 4.8056768558951966, 'classes' => 448]);
+
+        self::assertSame(
+            ['complexity' => 4.81, 'loc' => 44913],
+            $measurement->values([Metric::Complexity, Metric::LinesOfCode]),
+        );
+    }
+
+    public function testTheInterpretedMeasurementCarriesEveryMetricAndOnlyTheSharesThereAre(): void
+    {
+        $interpreted = (new Measurement(['loc' => 200, 'cloc' => 50]))->interpreted();
+
+        self::assertCount(\count(Metric::cases()), $interpreted['values']);
+        self::assertSame(200, $interpreted['values']['loc']);
+        self::assertNull($interpreted['values']['classes']);
+        self::assertSame(['comment-lines' => 25.0], $interpreted['shares']);
+    }
+}

--- a/tests/ComplexityReport/Metric/MetricSelectionTest.php
+++ b/tests/ComplexityReport/Metric/MetricSelectionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\ComplexityReport\Metric;
+
+use App\ComplexityReport\Metric\Metric;
+use App\ComplexityReport\Metric\MetricSelection;
+use PHPUnit\Framework\TestCase;
+
+final class MetricSelectionTest extends TestCase
+{
+    public function testTheChartNobodyToldAnythingIsTheMetricTheReportIsAbout(): void
+    {
+        $selection = MetricSelection::fromInput('');
+
+        self::assertSame([Metric::Complexity], $selection->getPicked());
+        self::assertSame(Metric::Complexity, $selection->getActive());
+        self::assertTrue($selection->isDefault());
+    }
+
+    public function testTheOrderOfTheQueryStringIsTheOrderOfTheTabs(): void
+    {
+        $selection = MetricSelection::fromInput('loc,complexity');
+
+        self::assertSame([Metric::LinesOfCode, Metric::Complexity], $selection->getPicked());
+        self::assertSame(['loc', 'complexity'], $selection->getSlugs());
+        self::assertFalse($selection->isDefault());
+    }
+
+    /**
+     * A chart opens on its first tab, and says which one it opens on only when that is not it.
+     */
+    public function testTheFirstMetricIsTheOneTheChartOpensOn(): void
+    {
+        $selection = MetricSelection::fromInput('loc,complexity');
+
+        self::assertSame(Metric::LinesOfCode, $selection->getActive());
+        self::assertTrue($selection->isFirstActive());
+    }
+
+    public function testTheAddressCanNameTheTabThatIsOpen(): void
+    {
+        $selection = MetricSelection::fromInput('loc,complexity', 'complexity');
+
+        self::assertSame([Metric::LinesOfCode, Metric::Complexity], $selection->getPicked());
+        self::assertSame(Metric::Complexity, $selection->getActive());
+        self::assertFalse($selection->isFirstActive());
+    }
+
+    /**
+     * A tab that is not one of the chart's own is not a tab, so the chart opens where it would anyway -
+     * an address is edited by hand and shared, and neither has to be right for it to draw something.
+     */
+    public function testAMetricTheChartDoesNotCarryCannotBeTheOpenTab(): void
+    {
+        $selection = MetricSelection::fromInput('loc,complexity', 'traits');
+
+        self::assertSame(Metric::LinesOfCode, $selection->getActive());
+    }
+
+    /**
+     * The query string is a link people read, edit and share, so what is not a metric of the report is
+     * dropped the way a repository that is not in it is - an address that says something the report
+     * cannot draw still draws what it can.
+     */
+    public function testWhatIsNotAMetricIsDropped(): void
+    {
+        $selection = MetricSelection::fromInput('loc,classCcnAvg,,complexity');
+
+        self::assertSame([Metric::LinesOfCode, Metric::Complexity], $selection->getPicked());
+    }
+
+    public function testNothingLeftOfASelectionIsStillAChart(): void
+    {
+        self::assertSame([Metric::Complexity], MetricSelection::fromInput('nonsense')->getPicked());
+    }
+
+    public function testAMetricIsOneTabHoweverOftenItIsNamed(): void
+    {
+        $selection = MetricSelection::fromInput('LOC, loc ,loc');
+
+        self::assertSame([Metric::LinesOfCode], $selection->getPicked());
+        self::assertTrue($selection->has(Metric::LinesOfCode));
+        self::assertFalse($selection->has(Metric::Complexity));
+    }
+
+    /**
+     * The chart used to be a switch between two numbers, addressed in the singular. Those links were
+     * handed out, and a switch between two is a selection of one.
+     */
+    public function testTheAddressOfTheSwitchThisGrewOutOfStillSaysWhatItMeant(): void
+    {
+        self::assertSame([Metric::LinesOfCode], MetricSelection::fromInput('', 'loc')->getPicked());
+        self::assertSame([Metric::Complexity], MetricSelection::fromInput('', 'complexity')->getPicked());
+    }
+
+    public function testASelectionOverridesTheSwitchItGrewOutOf(): void
+    {
+        self::assertSame([Metric::Complexity], MetricSelection::fromInput('complexity', 'loc')->getPicked());
+    }
+}

--- a/tests/ComplexityReport/Metric/MetricTest.php
+++ b/tests/ComplexityReport/Metric/MetricTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\ComplexityReport\Metric;
+
+use App\ComplexityReport\Metric\Metric;
+use App\ComplexityReport\Metric\MetricGroup;
+use PHPUnit\Framework\TestCase;
+use SebastianBergmann\PHPLOC\Analyser;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * The catalog says what a number is called and where it comes from. What it cannot say by itself is
+ * whether the number is still there: `source()` names a key of a phploc measurement, and a metric whose
+ * key phploc does not count is a chart of nulls. So the measurement these run against is a real one,
+ * taken here, the way {@see \App\Tests\ComplexityReport\PhplocReportTest} takes one.
+ */
+final class MetricTest extends TestCase
+{
+    private string $directory;
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->directory = sys_get_temp_dir().'/metric-'.bin2hex(random_bytes(6));
+
+        $this->filesystem->dumpFile($this->directory.'/code.php', <<<'PHP'
+            <?php
+
+            namespace Measured;
+
+            final class Branching
+            {
+                public const LIMIT = 10;
+
+                public function branch(int $value): string
+                {
+                    return $value > self::LIMIT ? 'over' : 'under';
+                }
+            }
+            PHP);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->directory);
+    }
+
+    public function testEveryMetricIsCountedByPhploc(): void
+    {
+        $measurement = $this->measure();
+
+        foreach (Metric::cases() as $metric) {
+            self::assertArrayHasKey(
+                $metric->source(),
+                $measurement,
+                sprintf('%s reads a key phploc does not count', $metric->name),
+            );
+        }
+    }
+
+    public function testTheMetricTheReportIsAboutIsTheAverageComplexityOfAClass(): void
+    {
+        // the number every trend, ranking and risk band of the report is computed from
+        self::assertSame('classCcnAvg', Metric::default()->source());
+        self::assertSame(MetricGroup::Complexity, Metric::default()->group());
+        self::assertTrue(Metric::default()->carriesLevel());
+    }
+
+    /**
+     * A slug is what a chart is shared as, and a key is what phploc stored - neither may be two things
+     * at once, or a link would draw something else than it says.
+     */
+    public function testEveryMetricIsAddressedByOneSlugAndReadsOneKey(): void
+    {
+        $slugs = array_map(static fn (Metric $metric) => $metric->value, Metric::cases());
+        $sources = array_map(static fn (Metric $metric) => $metric->source(), Metric::cases());
+
+        self::assertSame($slugs, array_unique($slugs));
+        self::assertSame($sources, array_unique($sources));
+    }
+
+    /**
+     * A part is only a part of something in the same section: a percentage is read against the number
+     * standing above it, which is what the indentation of the interpreted measurement says.
+     */
+    public function testAPartBelongsToTheSectionOfItsWhole(): void
+    {
+        foreach (Metric::cases() as $metric) {
+            $whole = $metric->partOf();
+
+            if (null !== $whole) {
+                self::assertSame($whole->group(), $metric->group(), sprintf('%s is a part of another section', $metric->name));
+                self::assertNotSame($whole, $metric);
+            }
+        }
+    }
+
+    public function testEveryMetricSaysWhatItIsAndWhatItIsWorth(): void
+    {
+        foreach (Metric::cases() as $metric) {
+            self::assertNotSame('', $metric->label());
+            self::assertNotSame('', $metric->about());
+            self::assertStringEndsWith('.', $metric->about(), sprintf('%s does not explain itself in a sentence', $metric->name));
+        }
+    }
+
+    public function testEverySectionCarriesItsMetricsInTheOrderOfTheCatalog(): void
+    {
+        $grouped = [];
+
+        foreach (MetricGroup::cases() as $group) {
+            self::assertNotSame([], $group->metrics());
+
+            $grouped = [...$grouped, ...$group->metrics()];
+        }
+
+        // the catalog is the order the report reads a measurement in, and no metric falls out of it
+        self::assertSame(Metric::cases(), $grouped);
+    }
+
+    /**
+     * @return array<string, float|int>
+     */
+    private function measure(): array
+    {
+        /** @var array<string, float|int> $measurement */
+        $measurement = (new Analyser())->countFiles([$this->directory.'/code.php'], false);
+
+        return $measurement;
+    }
+}


### PR DESCRIPTION
A measurement has sixty-two numbers in it and the report drew two of them; the other
sixty sat in the json blob a release carries and were a re-clone away from being read.
They are all in the chart now.

### The catalog

`Metric` is **54 of those 62**, each addressed by a slug (`?metrics=complexity,loc`)
rather than by the phploc key behind it, since the query string is a link people read -
plus what it is called, one line saying what it counts, the section phploc prints it
under, the whole it is `partOf()`, how far it is rounded, whether the report has an
opinion about its direction and whether it carries a risk band. Left out are the five
minimums (`classCcnMin` is 1 in 96% of twenty thousand releases), `testClasses` /
`testMethods` (always 0) and `ccnMethods` - all of them still in the measurement and
still in the raw output.

`Measurement` reads a stored blob through it, `MetricSelection` parses `?metrics=` by
the rules the repositories of a chart already follow, and `MetricCatalog` hands the
whole thing to the browser so nothing about a metric is written down twice.

The blob stays a blob: the two promoted columns stay columns because the report is
sorted, ranked and trended by them in SQL, while the other sixty are read one release
or one line at a time and never ordered by.

### A second metric is a tab

Not a second axis and not a second chart - colour already says which repository a line
belongs to and cannot also say which number it is, and two scales in one frame let a
crossing look like a statement when what crossed was the scaling
([Datawrapper](https://www.datawrapper.de/blog/dual-axis-charts-guide),
[Flourish](https://flourish.studio/blog/dual-axis-charts/); SonarQube caps a graph at
three measures for the same reason). Drawn one at a time in the same frame - same
place, same width, same years - two metrics are compared by switching between them, and
switching keeps the years the reader is in.

The tabs sit inside the chart panel, on the row under the repository chips, ending on
the hairline that closes the panel head - so the head answers the two questions about a
chart in the order they are asked: which repositories, and in which number. A single
metric is still a tab there; with nothing to switch to it is not a choice but the only
place the chart says what it is drawing.

Every metric of a chart travels with every release, so switching is a redraw and never
a request; adding one is the fetch, and a line already on the page is asked only for
the number it is missing.

### Reading one release

The four figures over the release analysis are read in whichever metric the chart is
open on, so switching a tab re-reads the release. Under them the panel lists every
picked metric, and folded below it stands the rest of the measurement: all 54 numbers
in phploc's four sections, indented under the whole they are part of, with their share
and their change since the previous release, each name a button that draws it. That is
`owner/repository/<tag>/metrics`; the raw output next to it is the same measurement as
phploc printed it.

### Rebased onto #43

The branch predates the editorial rework, so it was rebased onto it and the design
re-thought rather than merged hunk by hunk: the two-way segmented metric switch does
not survive 54 metrics, and the headline figures were hardcoded to complexity and LOC,
which say nothing when the chart is open on static method calls.

Carried along: the release rail keeps its tab for a single line too, a share written
under a figure that is itself a change now carries that change's sign, and
`.tabs--series` no longer reaches the one pixel past its row that gave a sideways
scrolling row a vertical scrollbar. CLAUDE.md catches up with #43 as well.

### Checks

178 tests, phpstan level 8, php-cs-fixer, prettier, twig/yaml/container lint all green.
Driven end to end in a headless browser: tab switching keeps the years and drops the
y-zoom, adding from the box and from the measurement table both open the new tab, the
tab `×` removes, the query string round-trips, legacy `?metric=loc` still opens what it
named, and the raw dialog still opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
